### PR TITLE
Remove the {ref:} indirect references from the data types

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 12 * * 1'
 
 jobs:
   publish:

--- a/change/@ot-builder-cli-proc-2020-03-16-04-05-52-remove-ref-property.json
+++ b/change/@ot-builder-cli-proc-2020-03-16-04-05-52-remove-ref-property.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Remove the {ref:} indirect references from the data types.",
+  "packageName": "@ot-builder/cli-proc",
+  "email": "belleve@typeof.net",
+  "commit": "6d85c7a61ae94d3fcc7cdf7bff411e35dd3ab4ab",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T11:05:45.143Z"
+}

--- a/change/@ot-builder-ft-glyphs-2020-03-16-04-05-52-remove-ref-property.json
+++ b/change/@ot-builder-ft-glyphs-2020-03-16-04-05-52-remove-ref-property.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Remove the {ref:} indirect references from the data types.",
+  "packageName": "@ot-builder/ft-glyphs",
+  "email": "belleve@typeof.net",
+  "commit": "6d85c7a61ae94d3fcc7cdf7bff411e35dd3ab4ab",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T11:05:46.575Z"
+}

--- a/change/@ot-builder-ft-layout-2020-03-16-04-05-52-remove-ref-property.json
+++ b/change/@ot-builder-ft-layout-2020-03-16-04-05-52-remove-ref-property.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Remove the {ref:} indirect references from the data types.",
+  "packageName": "@ot-builder/ft-layout",
+  "email": "belleve@typeof.net",
+  "commit": "6d85c7a61ae94d3fcc7cdf7bff411e35dd3ab4ab",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T11:05:48.030Z"
+}

--- a/change/@ot-builder-io-bin-layout-2020-03-16-04-05-52-remove-ref-property.json
+++ b/change/@ot-builder-io-bin-layout-2020-03-16-04-05-52-remove-ref-property.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Remove the {ref:} indirect references from the data types.",
+  "packageName": "@ot-builder/io-bin-layout",
+  "email": "belleve@typeof.net",
+  "commit": "6d85c7a61ae94d3fcc7cdf7bff411e35dd3ab4ab",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T11:05:48.974Z"
+}

--- a/change/@ot-builder-io-bin-ttf-2020-03-16-04-05-52-remove-ref-property.json
+++ b/change/@ot-builder-io-bin-ttf-2020-03-16-04-05-52-remove-ref-property.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Remove the {ref:} indirect references from the data types.",
+  "packageName": "@ot-builder/io-bin-ttf",
+  "email": "belleve@typeof.net",
+  "commit": "6d85c7a61ae94d3fcc7cdf7bff411e35dd3ab4ab",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T11:05:50.006Z"
+}

--- a/change/@ot-builder-rectify-font-2020-03-16-04-05-52-remove-ref-property.json
+++ b/change/@ot-builder-rectify-font-2020-03-16-04-05-52-remove-ref-property.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Remove the {ref:} indirect references from the data types.",
+  "packageName": "@ot-builder/rectify-font",
+  "email": "belleve@typeof.net",
+  "commit": "6d85c7a61ae94d3fcc7cdf7bff411e35dd3ab4ab",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T11:05:50.982Z"
+}

--- a/change/@ot-builder-test-util-2020-03-16-04-05-52-remove-ref-property.json
+++ b/change/@ot-builder-test-util-2020-03-16-04-05-52-remove-ref-property.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Remove the {ref:} indirect references from the data types.",
+  "packageName": "@ot-builder/test-util",
+  "email": "belleve@typeof.net",
+  "commit": "6d85c7a61ae94d3fcc7cdf7bff411e35dd3ab4ab",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T11:05:52.037Z"
+}

--- a/doc/pages/references/ot/glyph.mdx
+++ b/doc/pages/references/ot/glyph.mdx
@@ -90,15 +90,11 @@ Defines a metric advance of a glyph.
 
 ### Interface <Decl s={Ot.Glyph.Geometry}/>
 
-Defined as <R s={Ot.Glyph.GeometryT(record({ref:Ot.Glyph.Geometry}))}/>
-
-### Interface <Decl s={Ot.Glyph.GeometryT("E")}/>
-
 Defines as the union of the following cases.
 
  * <R s={Ot.Glyph.ContourSet}/>
  * <R s={Ot.Glyph.TtReference}/>
- * <R s={Ot.Glyph.GeometryListT("E")}/>
+ * <R s={Ot.Glyph.GeometryList}/>
 
 #### Properties
 
@@ -170,9 +166,7 @@ Defines as the union of the following cases.
 
     When present, this reference follows TrueType's point-attachment rules.
 
-### Type <Decl s={Ot.Glyph.GeometryList}/>
-
-Defined as <R s={Ot.Glyph.GeometryListT(record({ref:Ot.Glyph.Geometry}))}/>
+### Case Type <Decl s={Ot.Glyph.GeometryList}/> | type = <R s={Ot.Glyph.GeometryType.GeometryList}/>
 
 #### Factory Methods
 
@@ -180,17 +174,15 @@ Defined as <R s={Ot.Glyph.GeometryListT(record({ref:Ot.Glyph.Geometry}))}/>
 
     Creates an <R s={Ot.Glyph.GeometryList}/> from its members.
 
-### Case Type <Decl s={Ot.Glyph.GeometryListT("E")}/> | type = <R s={Ot.Glyph.GeometryType.GeometryList}/>
-
 #### Inherits
 
- * <R s={Ot.Glyph.GeometryListProps("E")} />
+ * <R s={Ot.Glyph.GeometryListProp} />
 
-### Type <Decl s={Ot.Glyph.GeometryListProps("E")}/>
+### Type <Decl s={Ot.Glyph.GeometryListProp}/>
 
 #### Properties
 
- * <Member s={Ot.Glyph.GeometryList.items} type={array("E")}/>
+ * <Member s={Ot.Glyph.GeometryList.items} type={Ot.Glyph.Geometry}/>
 
     The sub items inside.
 

--- a/doc/pages/references/ot/gsub-gpos.mdx
+++ b/doc/pages/references/ot/gsub-gpos.mdx
@@ -107,17 +107,13 @@ Defined as <R s={Ot.GsubGpos.FeatureVariationT(Ot.Gsub.Lookup)}/>
 
 ### Type <Decl s={Ot.Gsub.Lookup} />
 
-Defined as <R s={Ot.Gsub.LookupT(record({ref:Ot.Gsub.Lookup}))}/>
-
-### Type <Decl s={Ot.Gsub.LookupT("E")} />
-
 Defined as a union of the following cases:
 
 * <R s={Ot.Gsub.Single}/>
 * <R s={Ot.Gsub.Multiple}/>
 * <R s={Ot.Gsub.Alternate}/>
 * <R s={Ot.Gsub.Ligature}/>
-* <R s={Ot.Gsub.ChainingT("E")}/>
+* <R s={Ot.Gsub.Chaining}/>
 * <R s={Ot.Gsub.ReverseSub}/>
 
 #### Properties
@@ -201,19 +197,15 @@ Defined as a union of the following cases:
 * <Member readonly s={Ot.Gsub.LigatureEntry.from} type={readonly(array(Ot.Glyph))}/>
 * <Member readonly s={Ot.Gsub.LigatureEntry.to} type={Ot.Glyph}/>
 
-### Type <Decl s={Ot.Gsub.Chaining}/>
-
-Defined as <R s = {Ot.Gsub.ChainingT(record({ref:Ot.Gsub.Lookup}))}/>.
+### Case Type <Decl s={Ot.Gsub.Chaining}/> | type = <R s={Ot.Gsub.LookupType.Chaining}/>
 
 #### Factory Methods
 
-* <Method static s={Ot.Gsub.Chaining.create} args={{props:optional(Ot.GsubGpos.ChainingProp(record({ref:Ot.Gsub.Lookup})))}}/>
-
-### Case Type <Decl s={Ot.Gsub.ChainingT("E")}/> | type = <R s={Ot.Gsub.LookupType.Chaining}/>
+* <Method static s={Ot.Gsub.Chaining.create} args={{props:optional(Ot.GsubGpos.ChainingProp(Ot.Gsub.Lookup))}}/>
 
 #### Inherits
 
-* <R s={Ot.GsubGpos.ChainingProp("E")}/>
+* <R s={Ot.GsubGpos.ChainingProp(Ot.Gsub.Lookup)}/>
 
 ### Case Type <Decl s={Ot.Gsub.ReverseSub}/> | type = <R s={Ot.Gsub.LookupType.ReverseSub}/>
 
@@ -284,10 +276,6 @@ Defined as <R s={Ot.GsubGpos.FeatureVariationT(Ot.Gpos.Lookup)}/>
 
 ### Type <Decl s={Ot.Gpos.Lookup} />
 
-Defined as <R s={Ot.Gpos.LookupT(record({ref:Ot.Gpos.Lookup}))}/>
-
-### Type <Decl s={Ot.Gpos.LookupT("E")} />
-
 Defined as a union of the following cases:
 
 * <R s={Ot.Gpos.Single}/>
@@ -296,7 +284,7 @@ Defined as a union of the following cases:
 * <R s={Ot.Gpos.MarkToBase}/>
 * <R s={Ot.Gpos.MarkToLigature}/>
 * <R s={Ot.Gpos.MarkToMark}/>
-* <R s={Ot.Gpos.ChainingT("E")}/>
+* <R s={Ot.Gpos.Chaining}/>
 
 #### Properties
 
@@ -425,19 +413,15 @@ Defined as a union of the following cases:
 * <Member s={Ot.Gpos.MarkToMarkProp.marks} type={map(Ot.Glyph,Ot.Gpos.MarkRecord)}/>
 * <Member s={Ot.Gpos.MarkToMarkProp.baseMarks} type={map(Ot.Glyph,Ot.Gpos.BaseRecord)}/>
 
-### Type <Decl s={Ot.Gpos.Chaining}/>
-
-Defined as <R s={Ot.Gpos.ChainingT(record({ref:Ot.Gpos.Lookup}))}/>.
+### Case Type <Decl s={Ot.Gpos.Chaining}/> | type = <R s={Ot.Gpos.LookupType.Chaining}/>
 
 #### Factory Methods
 
-* <Method static s={Ot.Gpos.Chaining.create}  args={{props:optional(Ot.GsubGpos.ChainingProp(record({ref:Ot.Gpos.Lookup})))}}/>
-
-### Case Type <Decl s={Ot.Gpos.ChainingT("E")}/> | type = <R s={Ot.Gpos.LookupType.Chaining}/>
+* <Method static s={Ot.Gpos.Chaining.create}  args={{props:optional(Ot.GsubGpos.ChainingProp(Ot.Gpos.Lookup))}}/>
 
 #### Inherits
 
-* <R s={Ot.GsubGpos.ChainingProp("E")}/>
+* <R s={Ot.GsubGpos.ChainingProp(Ot.Gpos.Lookup)}/>
 
 
 

--- a/packages/cli-proc/src/support/share-glyph-set/glyph-hasher.ts
+++ b/packages/cli-proc/src/support/share-glyph-set/glyph-hasher.ts
@@ -94,7 +94,7 @@ class HashGeometry {
             case Ot.Glyph.GeometryType.ContourSet:
                 return this.contourSet(geom);
             case Ot.Glyph.GeometryType.GeometryList:
-                return this.geometryList(geom.items.map(item => this.process(item.ref)));
+                return this.geometryList(geom.items.map(item => this.process(item)));
             case Ot.Glyph.GeometryType.TtReference:
                 return this.ttReference(geom);
         }

--- a/packages/ft-glyphs/src/geometry-handlers/shared.ts
+++ b/packages/ft-glyphs/src/geometry-handlers/shared.ts
@@ -48,9 +48,7 @@ export class OtGhPointAlg<PS extends PointSink> implements GeometryProcessor {
                 break;
             }
             case OtGlyph.GeometryType.GeometryList: {
-                for (const item of geom.items) {
-                    this.process(item.ref);
-                }
+                for (const item of geom.items) this.process(item);
                 break;
             }
         }

--- a/packages/ft-glyphs/src/ot-glyph/index.ts
+++ b/packages/ft-glyphs/src/ot-glyph/index.ts
@@ -23,8 +23,7 @@ export namespace OtGlyph {
     }
 
     // Exported geometry types
-    export type GeometryT<E> = ContourSet | TtReference | GeometryListT<E>;
-    export type Geometry = GeometryT<{ ref: Geometry }>;
+    export type Geometry = ContourSet | TtReference | GeometryList;
 
     export type ContourSetProps = GeneralGlyph.ContourSetPropsT<OtGlyph, OtVar.Value>;
     export type ContourSet = CaseType<typeof TAG.GeometryType.ContourSet, ContourSetProps>;
@@ -34,18 +33,15 @@ export namespace OtGlyph {
         }
     }
 
-    export type GeometryListProps<E> = GeneralGlyph.GeometryListPropsT<OtGlyph, OtVar.Value, E>;
-    export type GeometryListT<E> = CaseType<
-        typeof TAG.GeometryType.GeometryList,
-        GeometryListProps<E>
+    export type GeometryListProps = GeneralGlyph.GeometryListPropsT<
+        OtGlyph,
+        OtVar.Value,
+        Geometry
     >;
-    export type GeometryList = GeometryListT<{ ref: Geometry }>;
+    export type GeometryList = CaseType<typeof TAG.GeometryType.GeometryList, GeometryListProps>;
     export namespace GeometryList {
         export function create(items: Geometry[] = []): GeometryList {
-            return {
-                type: TAG.GeometryType.GeometryList,
-                items: items.map(geom => ({ ref: geom }))
-            };
+            return { type: TAG.GeometryType.GeometryList, items: [...items] };
         }
     }
 

--- a/packages/ft-layout/src/gsub-gpos/index.ts
+++ b/packages/ft-layout/src/gsub-gpos/index.ts
@@ -82,10 +82,9 @@ export namespace Gsub {
         () => ({ mapping: [] })
     );
 
-    export type ChainingProp<L> = GeneralLookup.ForwardChainingPropT<OtGlyph, OtVar.Value, L>;
-    export type ChainingT<L> = CaseType<typeof LT.Gsub.Chaining, ChainingProp<L>>;
-    export type Chaining = ChainingT<{ ref: Lookup }>;
-    export const Chaining = CaseCreator<typeof LT.Gsub.Chaining, ChainingProp<{ ref: Lookup }>>(
+    export type ChainingProp = GeneralLookup.ForwardChainingPropT<OtGlyph, OtVar.Value, Lookup>;
+    export type Chaining = CaseType<typeof LT.Gsub.Chaining, ChainingProp>;
+    export const Chaining = CaseCreator<typeof LT.Gsub.Chaining, ChainingProp>(
         LT.Gsub.Chaining,
         () => ({ rules: [] })
     );
@@ -97,8 +96,7 @@ export namespace Gsub {
         () => ({ rules: [] })
     );
 
-    export type LookupT<L> = Single | Multiple | Alternate | Ligature | ChainingT<L> | ReverseSub;
-    export type Lookup = LookupT<{ ref: Lookup }>;
+    export type Lookup = Single | Multiple | Alternate | Ligature | Chaining | ReverseSub;
     export import LookupType = LT.Gsub;
 
     // Lookup-internal data types
@@ -168,23 +166,21 @@ export namespace Gpos {
         () => ({ marks: new Map(), baseMarks: new Map() })
     );
 
-    export type ChainingProp<L> = GeneralLookup.ForwardChainingPropT<OtGlyph, OtVar.Value, L>;
-    export type ChainingT<L> = CaseType<typeof LT.Gpos.Chaining, ChainingProp<L>>;
-    export type Chaining = ChainingT<{ ref: Lookup }>;
-    export const Chaining = CaseCreator<typeof LT.Gpos.Chaining, ChainingProp<{ ref: Lookup }>>(
+    export type ChainingProp = GeneralLookup.ForwardChainingPropT<OtGlyph, OtVar.Value, Lookup>;
+    export type Chaining = CaseType<typeof LT.Gpos.Chaining, ChainingProp>;
+    export const Chaining = CaseCreator<typeof LT.Gpos.Chaining, ChainingProp>(
         LT.Gpos.Chaining,
         () => ({ rules: [] })
     );
 
-    export type LookupT<L> =
+    export type Lookup =
         | Single
         | Pair
         | Cursive
         | MarkToBase
         | MarkToMark
         | MarkToLigature
-        | ChainingT<L>;
-    export type Lookup = LookupT<{ ref: Lookup }>;
+        | Chaining;
     export import LookupType = LT.Gpos;
 
     // Lookup-internal data type aliases

--- a/packages/io-bin-layout/src/lookups/contextual-read.ts
+++ b/packages/io-bin-layout/src/lookups/contextual-read.ts
@@ -36,7 +36,7 @@ class CApplication<L> {
         const glyphSequenceIndex = view.uint16();
         const lookupListIndex = view.uint16();
         const lookup = siblings.at(lookupListIndex);
-        return { at: glyphSequenceIndex, apply: { ref: lookup } };
+        return { at: glyphSequenceIndex, apply: lookup };
     }
 }
 
@@ -70,7 +70,7 @@ class CIndividualClassRule<L> {
             lookAheadSequence = lookAheadIDs.map(n => srLookAhead.toGlyphSet(n, false));
             applicationCount = view.uint16();
         }
-        const rule: GsubGpos.ChainingRule<{ ref: L }> = {
+        const rule: GsubGpos.ChainingRule<L> = {
             match: [...gssBacktrack, ...inputSequence, ...lookAheadSequence],
             inputBegins: gssBacktrack.length,
             inputEnds: gssBacktrack.length + inputSequence.length,
@@ -87,7 +87,7 @@ class IndividualClassRuleSet<L> {
     public read(
         view: BinaryView,
         isChaining: boolean,
-        lookup: GsubGpos.ChainingProp<{ ref: L }>,
+        lookup: GsubGpos.ChainingProp<L>,
         startGlyphs: Set<OtGlyph>,
         srBacktrack: Resolver,
         srInput: Resolver,
@@ -116,7 +116,7 @@ class SubtableFormat1<L> {
     public read(
         view: BinaryView,
         isChaining: boolean,
-        lookup: GsubGpos.ChainingProp<{ ref: L }>,
+        lookup: GsubGpos.ChainingProp<L>,
         ctx: SubtableReadingContext<L>
     ) {
         const format = view.uint16();
@@ -152,7 +152,7 @@ class SubtableFormat2<L> {
     public read(
         view: BinaryView,
         isChaining: boolean,
-        lookup: GsubGpos.ChainingProp<{ ref: L }>,
+        lookup: GsubGpos.ChainingProp<L>,
         ctx: SubtableReadingContext<L>
     ) {
         const format = view.uint16();
@@ -200,7 +200,7 @@ class SubtableFormat3<L> {
     public read(
         view: BinaryView,
         isChaining: boolean,
-        lookup: GsubGpos.ChainingProp<{ ref: L }>,
+        lookup: GsubGpos.ChainingProp<L>,
         ctx: SubtableReadingContext<L>
     ) {
         const format = view.uint16();
@@ -231,7 +231,7 @@ class SubtableFormat3<L> {
             gssLookAhead = [];
         }
 
-        const rule: GsubGpos.ChainingRule<{ ref: L }> = {
+        const rule: GsubGpos.ChainingRule<L> = {
             match: [...gssBacktrack, ...gssInput, ...gssLookAhead],
             inputBegins: gssBacktrack.length,
             inputEnds: gssBacktrack.length + gssInput.length,
@@ -246,7 +246,7 @@ class SubtableFormat3<L> {
     }
 }
 
-abstract class ChainingContextualReader<L, CL extends L & GsubGpos.ChainingProp<{ ref: L }>>
+abstract class ChainingContextualReader<L, CL extends L & GsubGpos.ChainingProp<L>>
     implements LookupReader<L, CL> {
     constructor(private chaining: boolean) {}
     public abstract createLookup(): CL;

--- a/packages/io-bin-layout/src/lookups/test/contextual.test.ts
+++ b/packages/io-bin-layout/src/lookups/test/contextual.test.ts
@@ -35,12 +35,7 @@ test("GSUB/GPOS Contextual : Simple", () => {
         match: [TuGlyphSet(gOrd, 0), TuGlyphSet(gOrd, 1)],
         inputBegins: 0,
         inputEnds: 2,
-        applications: [
-            {
-                at: 0,
-                apply: { ref: lOrd.at(0) }
-            }
-        ]
+        applications: [{ at: 0, apply: lOrd.at(0) }]
     });
     lookup.rules.push({
         match: [
@@ -51,12 +46,7 @@ test("GSUB/GPOS Contextual : Simple", () => {
         ],
         inputBegins: 1,
         inputEnds: 3,
-        applications: [
-            {
-                at: 0,
-                apply: { ref: lOrd.at(1) }
-            }
-        ]
+        applications: [{ at: 0, apply: lOrd.at(1) }]
     });
 
     LookupRoundTripTest(lookup, roundtripConfig);

--- a/packages/io-bin-ttf/src/glyf/classifier.ts
+++ b/packages/io-bin-ttf/src/glyf/classifier.ts
@@ -73,10 +73,8 @@ class GeometryClassifier {
         this.allReference = false;
         this.collectedContourSets.push(OtGlyph.ContourSet.create(csProps.contours));
     }
-    public geometryList(glProps: OtGlyph.GeometryListProps<{ ref: OtGlyph.Geometry }>) {
-        for (const entry of glProps.items) {
-            this.process(entry.ref);
-        }
+    public geometryList(glProps: OtGlyph.GeometryListProps) {
+        for (const entry of glProps.items) this.process(entry);
     }
     public ttReference(refProps: OtGlyph.TtReferenceProps) {
         this.hasReference = true;

--- a/packages/io-bin-ttf/src/glyf/read.test.ts
+++ b/packages/io-bin-ttf/src/glyf/read.test.ts
@@ -66,8 +66,8 @@ test("Reading : TTF, static", () => {
         const geom = g300.geometry as OtGlyph.GeometryList;
         expect(geom.items.length).toBe(2);
 
-        const base = geom.items[0].ref as OtGlyph.TtReference;
-        const diacritic = geom.items[1].ref as OtGlyph.TtReference;
+        const base = geom.items[0] as OtGlyph.TtReference;
+        const diacritic = geom.items[1] as OtGlyph.TtReference;
 
         expect(base.to).toBe(gOrd.at(302));
         expect(diacritic.to).toBe(gOrd.at(806));

--- a/packages/io-bin-ttf/src/gvar/read.test.ts
+++ b/packages/io-bin-ttf/src/gvar/read.test.ts
@@ -60,8 +60,8 @@ test("Reading : TTF, variable", () => {
 
         const geom = g300.geometry as OtGlyph.GeometryList;
         expect(geom.items.length).toBe(2);
-        const base = geom.items[0].ref as OtGlyph.TtReference;
-        const diacritic = geom.items[1].ref as OtGlyph.TtReference;
+        const base = geom.items[0] as OtGlyph.TtReference;
+        const diacritic = geom.items[1] as OtGlyph.TtReference;
         expect(base.to).toBe(gOrd.at(302));
         expect(diacritic.to).toBe(gOrd.at(806));
         expect(

--- a/packages/io-bin-ttf/src/gvar/read.ts
+++ b/packages/io-bin-ttf/src/gvar/read.ts
@@ -114,7 +114,7 @@ class GeomVarPtrCollector {
             case OtGlyph.GeometryType.TtReference:
                 return new TtReferenceHolder(geom);
             case OtGlyph.GeometryType.GeometryList: {
-                const parts: GeomHolder[] = geom.items.map(item => this.process(item.ref));
+                const parts: GeomHolder[] = geom.items.map(item => this.process(item));
                 return new GeometryListHolder(parts);
             }
         }

--- a/packages/io-bin-ttf/src/gvar/write.ts
+++ b/packages/io-bin-ttf/src/gvar/write.ts
@@ -122,10 +122,10 @@ class GeomVarCollector {
         }
         return collected;
     }
-    public geometryList(geom: OtGlyph.GeometryListProps<{ ref: OtGlyph.Geometry }>) {
+    public geometryList(geom: OtGlyph.GeometryListProps) {
         const collected: OtVar.Value[][] = [];
         for (const entry of geom.items) {
-            const sub = this.process(entry.ref);
+            const sub = this.process(entry);
             for (const x of sub) collected.push(x);
         }
         return collected;

--- a/packages/io-bin-ttf/src/rectify/rectify.test.ts
+++ b/packages/io-bin-ttf/src/rectify/rectify.test.ts
@@ -19,7 +19,7 @@ describe("GLYF data rectification", () => {
         rectifyGlyphOrder(gOrd);
 
         // Geometry is changed after rectification
-        const ref2a = (from.geometry as OtGlyph.GeometryList).items[1].ref as OtGlyph.TtReference;
+        const ref2a = (from.geometry as OtGlyph.GeometryList).items[1] as OtGlyph.TtReference;
         expect(ref2a.transform.dx).toBe(-1);
         expect(ref2a.transform.dy).toBe(-1);
     });
@@ -52,7 +52,7 @@ describe("GLYF data rectification", () => {
         rectifyGlyphOrder(gOrd);
 
         // Geometry is changed after rectification
-        const ref2a = (from.geometry as OtGlyph.GeometryList).items[1].ref as OtGlyph.TtReference;
+        const ref2a = (from.geometry as OtGlyph.GeometryList).items[1] as OtGlyph.TtReference;
         expect(ref2a.transform.dx).toBe(6);
         expect(ref2a.transform.dy).toBe(6);
     });
@@ -74,8 +74,8 @@ describe("GLYF data rectification", () => {
         rectifyGlyphOrder(gOrd);
 
         // Geometry is changed after rectification
-        const ref2a = (from.geometry as OtGlyph.GeometryList).items[1].ref as OtGlyph.TtReference;
-        const ref3a = (from.geometry as OtGlyph.GeometryList).items[2].ref as OtGlyph.TtReference;
+        const ref2a = (from.geometry as OtGlyph.GeometryList).items[1] as OtGlyph.TtReference;
+        const ref3a = (from.geometry as OtGlyph.GeometryList).items[2] as OtGlyph.TtReference;
         expect(ref2a.transform.dx).toBe(0), expect(ref2a.transform.dy).toBe(1);
         expect(ref3a.transform.dx).toBe(0), expect(ref3a.transform.dy).toBe(2);
     });

--- a/packages/io-bin-ttf/src/rectify/rectify.ts
+++ b/packages/io-bin-ttf/src/rectify/rectify.ts
@@ -36,7 +36,7 @@ class AttachmentPointToCoordAlg {
             case OtGlyph.GeometryType.TtReference:
                 return this.ttReference(geom);
             case OtGlyph.GeometryType.GeometryList:
-                return this.geometryList(geom.items.map(item => this.process(item.ref)));
+                return this.geometryList(geom.items.map(item => this.process(item)));
         }
     }
     public contourSet(cs: OtGlyph.ContourSetProps): PointAttachmentHandler {

--- a/packages/rectify-font/src/glyph/rectify-alg.ts
+++ b/packages/rectify-font/src/glyph/rectify-alg.ts
@@ -30,7 +30,7 @@ export class OtGhRectifyGeomPointAttachmentAlg {
             case Ot.Glyph.GeometryType.ContourSet:
                 return this.contourSet(geom);
             case Ot.Glyph.GeometryType.GeometryList:
-                return this.geometryList(geom.items.map(item => this.process(item.ref)));
+                return this.geometryList(geom.items.map(item => this.process(item)));
             case Ot.Glyph.GeometryType.TtReference:
                 return this.ttReference(geom);
         }

--- a/packages/rectify-font/src/glyph/trace-alg.ts
+++ b/packages/rectify-font/src/glyph/trace-alg.ts
@@ -17,7 +17,7 @@ class TraceGlyphsAlg {
             case Ot.Glyph.GeometryType.ContourSet:
                 return this.contourSet(geom);
             case Ot.Glyph.GeometryType.GeometryList:
-                return this.geometryList(geom.items.map(item => this.process(item.ref)));
+                return this.geometryList(geom.items.map(item => this.process(item)));
             case Ot.Glyph.GeometryType.TtReference:
                 return this.ttReference(geom);
         }

--- a/packages/rectify-font/src/layout/gsub-gpos/lookup-removable-alg.ts
+++ b/packages/rectify-font/src/layout/gsub-gpos/lookup-removable-alg.ts
@@ -74,10 +74,10 @@ export class CLookupRemovableAlg {
     public gposMarkToLigature(props: Ot.Gpos.MarkToLigatureProp): boolean {
         return !props.marks.size || !props.bases.size;
     }
-    public gsubChaining(props: Ot.GsubGpos.ChainingProp<{ ref: Ot.Gsub.Lookup }>): boolean {
+    public gsubChaining(props: Ot.Gsub.ChainingProp): boolean {
         return !props.rules.length;
     }
-    public gposChaining(props: Ot.GsubGpos.ChainingProp<{ ref: Ot.Gpos.Lookup }>): boolean {
+    public gposChaining(props: Ot.Gpos.ChainingProp): boolean {
         return !props.rules.length;
     }
 }

--- a/packages/rectify-font/src/layout/gsub-gpos/rectify-alg.test.ts
+++ b/packages/rectify-font/src/layout/gsub-gpos/rectify-alg.test.ts
@@ -10,7 +10,7 @@ describe("GSUB Rectifier", () => {
             match: [new Set([a])],
             inputBegins: 0,
             inputEnds: 1,
-            applications: [{ at: 0, apply: { ref: chaining } }] // Circular
+            applications: [{ at: 0, apply: chaining }] // Circular
         });
         const correspondence = rectifyLookupList(
             [chaining],
@@ -21,7 +21,7 @@ describe("GSUB Rectifier", () => {
         const chainingDup = correspondence.get(chaining)! as Ot.Gsub.Chaining;
         expect(chainingDup).toBeTruthy();
         expect(chainingDup).not.toBe(chaining);
-        expect(chainingDup.rules[0].applications[0].apply.ref).toBe(chainingDup);
+        expect(chainingDup.rules[0].applications[0].apply).toBe(chainingDup);
     });
 });
 

--- a/packages/rectify-font/src/layout/gsub-gpos/rectify.ts
+++ b/packages/rectify-font/src/layout/gsub-gpos/rectify.ts
@@ -49,17 +49,17 @@ abstract class RectifyGlyphCoordAlgBase<L extends Ot.GsubGpos.LookupProp> {
     }
 
     protected processChainingRules(
-        props: Ot.GsubGpos.ChainingProp<{ ref: L }>,
-        ret: Ot.GsubGpos.ChainingProp<{ ref: L }>
+        props: Ot.GsubGpos.ChainingProp<L>,
+        ret: Ot.GsubGpos.ChainingProp<L>
     ) {
         ret.rules = [];
         for (const rule of props.rules) {
             const match1 = RectifyImpl.listAllT(this.rg, rule.match, RectifyImpl.Glyph.setAll);
             if (!match1 || !match1.length) continue;
-            const applications1: Ot.GsubGpos.ChainingApplication<{ ref: L }>[] = [];
+            const applications1: Ot.GsubGpos.ChainingApplication<L>[] = [];
             for (const app of rule.applications) {
-                const stub = this._cache.get(app.apply.ref);
-                if (stub) applications1.push({ at: app.at, apply: { ref: stub.demand } });
+                const stub = this._cache.get(app.apply);
+                if (stub) applications1.push({ at: app.at, apply: stub.demand });
             }
             ret.rules.push({
                 match: match1,
@@ -153,9 +153,7 @@ export class RectifyGsubGlyphCoordAlg extends RectifyGlyphCoordAlgBase<Ot.Gsub.L
         });
     }
 
-    private gsubChaining(
-        props: Ot.Gsub.ChainingProp<{ ref: Ot.Gsub.Lookup }>
-    ): RStub<Ot.Gsub.Lookup> {
+    private gsubChaining(props: Ot.Gsub.ChainingProp): RStub<Ot.Gsub.Lookup> {
         return RStub(Ot.Gsub.Chaining.create(), ret => {
             this.setMeta(props, ret);
             this.processChainingRules(props, ret);
@@ -285,9 +283,7 @@ export class RectifyGposGlyphCoordAlg extends RectifyGlyphCoordAlgBase<Ot.Gpos.L
         });
     }
 
-    public gposChaining(
-        props: Ot.GsubGpos.ChainingProp<{ ref: Ot.Gpos.Lookup }>
-    ): RStub<Ot.Gpos.Lookup> {
+    public gposChaining(props: Ot.Gpos.ChainingProp): RStub<Ot.Gpos.Lookup> {
         return RStub(Ot.Gpos.Chaining.create(), ret => {
             this.setMeta(props, ret);
             this.processChainingRules(props, ret);

--- a/packages/rectify-font/src/layout/gsub-gpos/trace.ts
+++ b/packages/rectify-font/src/layout/gsub-gpos/trace.ts
@@ -14,7 +14,7 @@ export function traceGpos(table: Ot.Gpos.Table): GlyphTraceProc {
 }
 
 class ItTraceGlyph<E> {
-    public process(lookup: Ot.Gsub.LookupT<E> | Ot.Gpos.LookupT<E>): GlyphTraceProc {
+    public process(lookup: Ot.Gsub.Lookup | Ot.Gpos.Lookup): GlyphTraceProc {
         switch (lookup.type) {
             case Ot.Gsub.LookupType.Single:
                 return this.gsubSingle(lookup);

--- a/packages/test-util/src/glyph-identity.ts
+++ b/packages/test-util/src/glyph-identity.ts
@@ -157,8 +157,8 @@ export namespace GlyphIdentity {
     ) {
         expect(expected.items.length).toBe(actual.items.length);
         for (let rid = 0; rid < expected.items.length; rid++) {
-            const expectedItem = expected.items[rid].ref;
-            const actualItem = actual.items[rid].ref;
+            const expectedItem = expected.items[rid];
+            const actualItem = actual.items[rid];
             testInitGeometry(expectedItem, actualItem, mode, tolerance);
         }
     }

--- a/packages/test-util/src/layout-identity/lookup/lookup-chaining.ts
+++ b/packages/test-util/src/layout-identity/lookup/lookup-chaining.ts
@@ -7,8 +7,8 @@ import { LookupCtx, StdCompare } from "../../compar-util";
 export namespace ChainingLookupIdentity {
     function ruleMatch<L>(
         bmg: LookupCtx<OtGlyph, L>,
-        rExp: GsubGpos.ChainingRule<{ ref: L }>,
-        rAct: GsubGpos.ChainingRule<{ ref: L }>
+        rExp: GsubGpos.ChainingRule<L>,
+        rAct: GsubGpos.ChainingRule<L>
     ) {
         if (rExp.match.length !== rAct.match.length) return false;
         if (rExp.inputBegins !== rAct.inputBegins) return false;
@@ -24,14 +24,14 @@ export namespace ChainingLookupIdentity {
             rAct.applications
         )) {
             if (aa.at !== ab.at) return false;
-            if (ab.apply.ref !== bmg.lookups.forward(aa.apply.ref)) return false;
+            if (ab.apply !== bmg.lookups.forward(aa.apply)) return false;
         }
         return true;
     }
     function testSingle<L>(
         bmg: LookupCtx<OtGlyph, L>,
-        expected: GsubGpos.ChainingProp<{ ref: L }>,
-        actual: GsubGpos.ChainingProp<{ ref: L }>
+        expected: GsubGpos.ChainingProp<L>,
+        actual: GsubGpos.ChainingProp<L>
     ) {
         for (const rExp of expected.rules) {
             let foundMatchRule = false;


### PR DESCRIPTION
This is a reminder of (former) tagless-final datatype definition.
It is no longer used so remove that.