### PR TITLE
Remove Ot.Var.ValueCollector

### DIFF
--- a/change/@ot-builder-var-store-2020-03-18-17-31-34-remove-ot-var-valuecollector.json
+++ b/change/@ot-builder-var-store-2020-03-18-17-31-34-remove-ot-var-valuecollector.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Removal of Ot.Var.ValueCollector; Move original value collector implementation into packages/var-store.",
+  "packageName": "@ot-builder/var-store",
+  "email": "belleve@typeof.net",
+  "commit": "853c7e6b330acb4f2682c1dbc73b1867cb105df9",
+  "dependentChangeType": "patch",
+  "date": "2020-03-19T00:31:33.535Z"
+}

--- a/change/@ot-builder-variance-2020-03-18-17-31-34-remove-ot-var-valuecollector.json
+++ b/change/@ot-builder-variance-2020-03-18-17-31-34-remove-ot-var-valuecollector.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Removal of Ot.Var.ValueCollector; Move original value collector implementation into packages/var-store.",
+  "packageName": "@ot-builder/variance",
+  "email": "belleve@typeof.net",
+  "commit": "853c7e6b330acb4f2682c1dbc73b1867cb105df9",
+  "dependentChangeType": "patch",
+  "date": "2020-03-19T00:31:34.840Z"
+}

--- a/doc/pages/references/ot/var.mdx
+++ b/doc/pages/references/ot/var.mdx
@@ -127,27 +127,3 @@ A master set collects masters and associates an unique number to masters that ar
 
  * <Method s={Ot.Var.ValueFactory.create} args={{origin:optional(number),variance:optional(iterable(tuple(Ot.Var.Master,number)))}} returns={Ot.Var.Value} />
  * <Method s={Ot.Var.ValueFactory.make} args={{['...xs']:array(either(Ot.Var.Value,tuple(Ot.Var.Master,number)))}} returns={Ot.Var.Value} />
-
-
-## Value Collection
-
-### Class <Decl s={Ot.Var.ValueCollector("D")}/>
-
-#### Factory Methods
-
- * <Fn s={Ot.Var.Create.ValueCollector('D')} args={{factory:Ot.Var.CollectedValueFactory("D")}} returns={Ot.Var.ValueCollector("D")}/>
-
-#### Properties
-
- * <Member readonly s={Ot.Var.ValueCollector.size} type={number} />
-
-#### Methods
-
- * <Method s={Ot.Var.ValueCollector.collect} args={{x:Ot.Var.Value}} returns="D" />
- * <Method s={Ot.Var.ValueCollector.settleDown} args={{}} returns="void" />
- * <Method s={Ot.Var.ValueCollector.resolveDeltas} args={{deltaMA:array(number)}} returns={array(number)} />
- * <Method s={Ot.Var.ValueCollector.getMasterList} args={{}} returns={array(tuple(number,Ot.Var.Master))} />
-
-### Type <Decl s={Ot.Var.CollectedValueFactory("D")}/>
-
-Defined as <R s={pi({col: Ot.Var.ValueCollector('D'),origin:number,deltaMA:array(number)},"D")}/>

--- a/packages/var-store/src/tvs/write/collect.ts
+++ b/packages/var-store/src/tvs/write/collect.ts
@@ -1,18 +1,20 @@
 import { ImpLib } from "@ot-builder/common-impl";
-import { GeneralVarInternalImpl, OtVar } from "@ot-builder/variance";
+import { OtVar } from "@ot-builder/variance";
 
-export class TvsCollector extends GeneralVarInternalImpl.ValueCollector<
+import { DelayValueCollector } from "../../common/value-collector";
+
+export class TvsCollector extends DelayValueCollector<
     OtVar.Dim,
     OtVar.Master,
     OtVar.Value,
     DelayDeltaValue
 > {
-    constructor(masterCollector: OtVar.MasterSet) {
-        super(
-            OtVar.Ops,
-            masterCollector,
-            (col, origin, deltaMA) => new DelayDeltaValue(col, origin, deltaMA)
-        );
+    constructor() {
+        super(OtVar.Ops, OtVar.Create.MasterSet());
+    }
+
+    protected createCollectedValue(origin: number, deltaMA: number[]) {
+        return new DelayDeltaValue(this, origin, deltaMA);
     }
 }
 

--- a/packages/var-store/src/tvs/write/index.ts
+++ b/packages/var-store/src/tvs/write/index.ts
@@ -26,7 +26,7 @@ export interface TupleVariationBuildSource {
 
 export const TupleVariationWriteOpt = WriteOpt(
     (source: TupleVariationBuildSource, ctx: TupleVariationBuildContext) => {
-        const col = new TvsCollector(OtVar.Create.MasterSet());
+        const col = new TvsCollector();
         const data = collectDeltaData(col, source.dimensions, source.data);
         const tuc = new MasterToTupleConverter(ctx.designSpace, !!ctx.forceIntermediate);
 

--- a/packages/variance/src/index.ts
+++ b/packages/variance/src/index.ts
@@ -1,9 +1,5 @@
 import { Data } from "@ot-builder/prelude";
 
-import {
-    GeneralCollectedValueFactory,
-    GeneralVariableValueCollector
-} from "./general-impl/value-collector";
 import { VarianceDim } from "./interface/dimension";
 import { VarianceInstance } from "./interface/instance";
 import {
@@ -30,20 +26,8 @@ export namespace GeneralVar {
         M extends Master<A>
     > = VarianceMasterCollectResult<A, M>;
     export type Ops<A extends Dim, M extends Master<A>, X> = VariableOps<A, M, X>;
-    export type ValueFactory<A extends Dim, M extends Master<A>, X> = VariableCreator<A, M, X>;
-    export type ValueCollector<
-        A extends VarianceDim,
-        M extends VarianceMaster<A>,
-        X,
-        D
-    > = GeneralVariableValueCollector<A, M, X, D>;
-    export type CollectedValueFactory<
-        A extends VarianceDim,
-        M extends VarianceMaster<A>,
-        X,
-        D
-    > = GeneralCollectedValueFactory<A, M, X, D>;
     export type Instance<A extends Dim> = VarianceInstance<A>;
+    export type ValueFactory<A extends Dim, M extends Master<A>, X> = VariableCreator<A, M, X>;
 }
 
 export namespace OtVar {
@@ -57,9 +41,6 @@ export namespace OtVar {
     export type MasterSet = VarianceMasterSet<Dim, Master>;
     export type Ops = VariableOps<Dim, Master, Value>;
     export type ValueFactory = VariableCreator<Dim, Master, Value>;
-    export type ValueCollector<D> = GeneralVariableValueCollector<Dim, Master, Value, D>;
-    export type CollectedValueFactory<D> = GeneralCollectedValueFactory<Dim, Master, Value, D>;
-
     // Factory exports
     export const Ops = OtVarOps;
     export namespace Create {
@@ -69,15 +50,8 @@ export namespace OtVar {
         export function MasterSet(): MasterSet {
             return new OtVarMasterSet<Dim>();
         }
-        export function ValueCollector<D>(dvf: CollectedValueFactory<D>): ValueCollector<D> {
-            return new GeneralVariableValueCollector(Ops, MasterSet(), dvf);
-        }
         export function ValueFactory(ms?: MasterSet): ValueFactory {
             return new OtVarCreatorImpl(ms || MasterSet(), OtVarOps);
         }
     }
-}
-
-export namespace GeneralVarInternalImpl {
-    export const ValueCollector = GeneralVariableValueCollector;
 }

--- a/packages/variance/src/otvar-impl/index.ts
+++ b/packages/variance/src/otvar-impl/index.ts
@@ -1,5 +1,4 @@
 export * from "./master-set";
-export * from "../general-impl/value-collector";
 export * from "./ops";
 export * from "./master";
 export * from "./value";


### PR DESCRIPTION
`Ot.Var.ValueCollector` is used when buliding var stores only, and it should not become a public interface.