### PR TITLE
Sort records by tag in mvar

### DIFF
--- a/change/@ot-builder-io-bin-metadata-2020-04-14-23-20-11-mvar-sort-records.json
+++ b/change/@ot-builder-io-bin-metadata-2020-04-14-23-20-11-mvar-sort-records.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "sort mvar records by tag",
+  "packageName": "@ot-builder/io-bin-metadata",
+  "email": "c@cyano.cn",
+  "dependentChangeType": "patch",
+  "date": "2020-04-14T15:20:11.329Z"
+}

--- a/packages/io-bin-metadata/src/mvar/index.ts
+++ b/packages/io-bin-metadata/src/mvar/index.ts
@@ -137,6 +137,8 @@ export const MvarTableIo = {
             const r = ivs.valueToInnerOuterID(lens.get());
             if (r) rec.push([tag, r.outer, r.inner]);
         }
+        // sort records by tag
+        rec.sort((a, b) => (a[0] > b[0] ? 1 : -1));
 
         frag.uint16(1)
             .uint16(0)


### PR DESCRIPTION
OTSpec / Tables / MVAR / Processing:
> Records in the array are stored in binary order of values in the valueTag fields.

Firefox 75.0 rejects `SourceCodeVariable-Roman.otf` (Version 1.010) after a read-write round trip.