### PR TITLE
TTC Bundle: fix arg handler

### DIFF
--- a/change/otb-ttc-bundle-2020-04-29-03-30-32-ttc-bundle-fix-arg-handler.json
+++ b/change/otb-ttc-bundle-2020-04-29-03-30-32-ttc-bundle-fix-arg-handler.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix argument handler of `-o`",
+  "packageName": "otb-ttc-bundle",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-04-29T10:30:32.657Z"
+}

--- a/packages/cli-ttc-bundle/src/arg-parser.ts
+++ b/packages/cli-ttc-bundle/src/arg-parser.ts
@@ -10,15 +10,27 @@ export class ArgParser {
 
     arg(x: string) {
         if (x[0] === "-" && this.acceptArgs) {
-            if (x === "--") this.acceptArgs = false;
-            else if (x === "-h" || x === "--help") this.displayHelp = true;
-            else if (x === "-u" || x === "--unify") this.unify = true;
-            else if (x === "-x" || x === "--sparse") this.sparse = true;
-            else if (x === "-o") this.argName = x;
-            else throw new Error("Unrecognized option " + x);
+            this.handleOption(x);
         } else {
+            this.handleArgument(x);
+        }
+    }
+
+    private handleOption(x: string) {
+        if (x === "--") this.acceptArgs = false;
+        else if (x === "-h" || x === "--help") this.displayHelp = true;
+        else if (x === "-u" || x === "--unify") this.unify = true;
+        else if (x === "-x" || x === "--sparse") this.sparse = true;
+        else if (x === "-o") this.argName = x;
+        else throw new Error("Unrecognized option " + x);
+    }
+
+    private handleArgument(x: string) {
+        if (this.argName) {
             if (this.argName === "-o") this.output = x;
-            else this.inputs.push(x);
+            this.argName = null;
+        } else {
+            this.inputs.push(x);
         }
     }
 }

--- a/packages/cli-ttc-bundle/src/index.ts
+++ b/packages/cli-ttc-bundle/src/index.ts
@@ -17,6 +17,13 @@ export async function cliMain(argv: string[]) {
         return;
     }
 
+    if (!args.inputs || !args.inputs.length) {
+        throw new Error("Please specify at least one input font. Exit.");
+    }
+    if (!args.output) {
+        throw new Error("Please specify an output. Exit");
+    }
+
     if (!args.unify && !args.sparse) {
         await simpleMerging(args);
     } else {


### PR DESCRIPTION
In the current code if `-o` occurs before input args, the input font arguments won't be treated as input, instead, they will overwrite the `-o` value. This PR fixed that.