### PR TITLE
Move Ot.Var `type`s to `class`es

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: [12.x, 14.x] # Current and LTS. No history versions
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -46,7 +46,7 @@ jobs:
         node-version: [12.x, 14.x] # Current and LTS. No history versions
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -71,7 +71,7 @@ jobs:
         node-version: [12.x] # Current and LTS. No history versions
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -96,7 +96,7 @@ jobs:
         node-version: [12.x] # Current and LTS. No history versions
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/prime.yml
+++ b/.github/workflows/prime.yml
@@ -18,7 +18,7 @@ jobs:
         node-version: [12.x, 14.x] # Current and LTS. No history versions
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -40,7 +40,7 @@ jobs:
         node-version: [12.x, 14.x] # Current and LTS. No history versions
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js v12
       uses: actions/setup-node@v1
       with:

--- a/change/@ot-builder-cli-proc-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
+++ b/change/@ot-builder-cli-proc-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move data types in Ot.Var from structs to classes.",
+  "packageName": "@ot-builder/cli-proc",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T01:27:15.064Z"
+}

--- a/change/@ot-builder-io-bin-cff-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
+++ b/change/@ot-builder-io-bin-cff-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move data types in Ot.Var from structs to classes.",
+  "packageName": "@ot-builder/io-bin-cff",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T01:27:15.390Z"
+}

--- a/change/@ot-builder-io-bin-glyph-store-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
+++ b/change/@ot-builder-io-bin-glyph-store-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move data types in Ot.Var from structs to classes.",
+  "packageName": "@ot-builder/io-bin-glyph-store",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T01:27:15.686Z"
+}

--- a/change/@ot-builder-io-bin-layout-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
+++ b/change/@ot-builder-io-bin-layout-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move data types in Ot.Var from structs to classes.",
+  "packageName": "@ot-builder/io-bin-layout",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T01:27:15.974Z"
+}

--- a/change/@ot-builder-io-bin-metadata-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
+++ b/change/@ot-builder-io-bin-metadata-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move data types in Ot.Var from structs to classes.",
+  "packageName": "@ot-builder/io-bin-metadata",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T01:27:16.246Z"
+}

--- a/change/@ot-builder-io-bin-metric-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
+++ b/change/@ot-builder-io-bin-metric-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move data types in Ot.Var from structs to classes.",
+  "packageName": "@ot-builder/io-bin-metric",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T01:27:16.568Z"
+}

--- a/change/@ot-builder-io-bin-ttf-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
+++ b/change/@ot-builder-io-bin-ttf-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move data types in Ot.Var from structs to classes.",
+  "packageName": "@ot-builder/io-bin-ttf",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T01:27:16.879Z"
+}

--- a/change/@ot-builder-var-store-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
+++ b/change/@ot-builder-var-store-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move data types in Ot.Var from structs to classes.",
+  "packageName": "@ot-builder/var-store",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T01:27:17.207Z"
+}

--- a/change/@ot-builder-variance-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
+++ b/change/@ot-builder-variance-2020-05-14-18-27-17-move-ot-var-types-to-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move data types in Ot.Var from structs to classes.",
+  "packageName": "@ot-builder/variance",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T01:27:17.535Z"
+}

--- a/doc/pages/references/ot/var.mdx
+++ b/doc/pages/references/ot/var.mdx
@@ -46,11 +46,11 @@ Defined as <R s={Data.Maybe(readonly(map(Ot.Var.Dim,number)))} />.
  * <Member readonly s={Ot.Var.MasterDim.peak} type={number} />
  * <Member readonly s={Ot.Var.MasterDim.max} type={number} />
 
-### Type <Decl s={Ot.Var.Master} />
+### Class <Decl s={Ot.Var.Master} />
 
-#### Factory Methods
+#### Constructor
 
-* <Fn s={Ot.Var.Create.Master} args={{init:iterable(either(undefined,null,Ot.Var.MasterDim))}} />
+* <Method ctor s={Ot.Var.Master.constructor} args={{init:iterable(either(undefined,null,Ot.Var.MasterDim))}} />
 
   Create a <R s={Ot.Var.Master}/> from per-axis regions. `undefined` and `null` items are ignored.
 
@@ -66,7 +66,7 @@ Defined as <R s={Data.Maybe(readonly(map(Ot.Var.Dim,number)))} />.
  * <Method s={Ot.Var.Master.isSimple} args={{}} returns={boolean} />
 
 
-### Type <Decl s={Ot.Var.MasterSet} />
+### Class <Decl s={Ot.Var.MasterSet} />
 
 A master set collects masters and associates an unique number to masters that are distinguishable. Equivalent masters will share same index.
 
@@ -74,9 +74,9 @@ A master set collects masters and associates an unique number to masters that ar
 
 * <R s={iterable(tuple(Ot.Var.Master, number))} />
 
-#### Factory Methods
+#### Constructor
 
-* <Fn s={Ot.Var.Create.MasterSet} args={{}} returns={Ot.Var.MasterSet} />
+* <Method ctor s={Ot.Var.MasterSet.constructor} args={{}} />
 
 #### Methods
 
@@ -117,11 +117,11 @@ A master set collects masters and associates an unique number to masters that ar
  * <Method s={Ot.Var.Ops.isZero} args={{x:Ot.Var.Value}} returns={boolean} />
 
 
-### Type <Decl s={Ot.Var.ValueFactory}/>
+### Class <Decl s={Ot.Var.ValueFactory}/>
 
-#### Factory Methods
+#### Constructor
 
- * <Fn s={Ot.Var.Create.ValueFactory} args={{ms:optional(Ot.Var.MasterSet)}}/>
+ * <Method ctor s={Ot.Var.ValueFactory.constructor} args={{masterSet:optional(Ot.Var.MasterSet)}}/>
 
 #### Properties
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
         "prettier-eslint": "^9.0.1",
         "rimraf": "^2.6.3",
         "ts-node": "^8.3.0",
-        "typescript": "^3.8.0"
+        "typescript": "^3.9.0"
     }
 }

--- a/packages/cli-proc/src/support/design-unifier/value-process.ts
+++ b/packages/cli-proc/src/support/design-unifier/value-process.ts
@@ -50,13 +50,13 @@ export class MasterProcessor {
                 max: region.max
             };
         }
-        return Ot.Var.Create.Master(steps);
+        return new Ot.Var.Master(steps);
     }
 }
 
 export class ValueProcessor {
     constructor(private readonly mp: MasterProcessor) {}
-    private cr = Ot.Var.Create.ValueFactory();
+    private cr = new Ot.Var.ValueFactory();
 
     public toArrayRep(v: Ot.Var.Value) {
         const variances = Array.from(Ot.Var.Ops.varianceOf(v));

--- a/packages/io-bin-cff/src/char-string/write/draw-call-convert.test.ts
+++ b/packages/io-bin-cff/src/char-string/write/draw-call-convert.test.ts
@@ -9,21 +9,21 @@ import { mirSeqIsWellFormed } from "./test-util";
 
 const Wght = new OtVar.Dim("wght", 100, 400, 900);
 const Wdth = new OtVar.Dim("wdth", 25, 100, 200);
-const Bold = OtVar.Create.Master([
+const Bold = new OtVar.Master([
     { dim: Wght, min: 0, peak: 1, max: 1 },
     { dim: Wdth, min: -1, peak: 0, max: 1 }
 ]);
-const Wide = OtVar.Create.Master([
+const Wide = new OtVar.Master([
     { dim: Wght, min: -1, peak: 0, max: 1 },
     { dim: Wdth, min: 0, peak: 1, max: 1 }
 ]);
-const Corner = OtVar.Create.Master([
+const Corner = new OtVar.Master([
     { dim: Wght, min: 0, peak: 1, max: 1 },
     { dim: Wdth, min: 0, peak: 1, max: 1 }
 ]);
 
 test("CFF Encoding: Draw call conversion", () => {
-    const cr = OtVar.Create.ValueFactory();
+    const cr = new OtVar.ValueFactory();
     const ctx = new CffWriteContext(2, 1000);
     const dcrSeq = new CffDrawCallRaw(
         [
@@ -60,7 +60,7 @@ test("CFF Encoding: Draw call conversion", () => {
 });
 
 test("CFF Encoding: Draw call conversion should not overflow", () => {
-    const cr = OtVar.Create.ValueFactory();
+    const cr = new OtVar.ValueFactory();
     const ctx = new CffWriteContext(2, 1000);
     const a: OtVar.Value[] = [];
     for (let x = 0; x < 128; x++) {

--- a/packages/io-bin-cff/src/context/write.ts
+++ b/packages/io-bin-cff/src/context/write.ts
@@ -16,8 +16,7 @@ export class CffWriteContext {
         acceptVariation = true,
         gss: Data.Maybe<OtGlyph.Stat.Sink> = null
     ) {
-        if (version > 1 && acceptVariation)
-            this.ivs = WriteTimeIVS.create(OtVar.Create.MasterSet());
+        if (version > 1 && acceptVariation) this.ivs = WriteTimeIVS.create(new OtVar.MasterSet());
         if (version <= 1) this.strings = new CffStringSink();
         this.stat = new CffGlyphStatSink(gss);
     }

--- a/packages/io-bin-cff/src/interp/stack-machine.ts
+++ b/packages/io-bin-cff/src/interp/stack-machine.ts
@@ -6,8 +6,8 @@ import { OtVar } from "@ot-builder/variance";
 export class CffStackMachine {
     public ivd: ReadTimeIVD<OtVar.Dim, OtVar.Master, OtVar.Value> | null = null;
     public stack: OtVar.Value[] = [];
-    public vms = OtVar.Create.MasterSet();
-    private varCreator = OtVar.Create.ValueFactory(this.vms);
+    public vms = new OtVar.MasterSet();
+    private varCreator = new OtVar.ValueFactory(this.vms);
 
     constructor(public ivs?: Data.Maybe<ReadTimeIVS>) {
         if (ivs) this.ivd = ivs.tryGetIVD(0);

--- a/packages/io-bin-cff/src/interp/vsindex-blend.test.ts
+++ b/packages/io-bin-cff/src/interp/vsindex-blend.test.ts
@@ -28,22 +28,22 @@ class MockInterpreter extends CffInterp.Interpreter {
 }
 
 const Axes = TestVariance.createWellKnownAxes();
-const Bold = OtVar.Create.Master([{ dim: Axes.wght, min: 0, peak: 1, max: 1 }]);
-const Wide = OtVar.Create.Master([{ dim: Axes.wdth, min: 0, peak: 1, max: 1 }]);
+const Bold = new OtVar.Master([{ dim: Axes.wght, min: 0, peak: 1, max: 1 }]);
+const Wide = new OtVar.Master([{ dim: Axes.wdth, min: 0, peak: 1, max: 1 }]);
 
 function createVS() {
     const ivs = ReadTimeIVS.Create();
     ivs.knownMasters = [Bold, Wide];
     const boldOnly = new ReadTimeIVD<OtVar.Dim, OtVar.Master, OtVar.Value>(
-        OtVar.Create.ValueFactory(OtVar.Create.MasterSet())
+        new OtVar.ValueFactory(new OtVar.MasterSet())
     );
     boldOnly.masterIDs = [0];
     const wideOnly = new ReadTimeIVD<OtVar.Dim, OtVar.Master, OtVar.Value>(
-        OtVar.Create.ValueFactory(OtVar.Create.MasterSet())
+        new OtVar.ValueFactory(new OtVar.MasterSet())
     );
     wideOnly.masterIDs = [1];
     const boldAndWide = new ReadTimeIVD<OtVar.Dim, OtVar.Master, OtVar.Value>(
-        OtVar.Create.ValueFactory(OtVar.Create.MasterSet())
+        new OtVar.ValueFactory(new OtVar.MasterSet())
     );
     boldAndWide.masterIDs = [0, 1];
     ivs.itemVariationData = [boldOnly, wideOnly, boldAndWide];
@@ -58,7 +58,7 @@ describe("CFF Interpreter", () => {
     });
 
     test("Should handle blend", () => {
-        const cr = OtVar.Create.ValueFactory();
+        const cr = new OtVar.ValueFactory();
         const ivs = createVS();
         const inter = new MockInterpreter(ivs);
         inter.operand(1, 2, 1).operator(CffOperator.Blend);
@@ -69,7 +69,7 @@ describe("CFF Interpreter", () => {
     });
 
     test("Should handle blend of multiple arguments", () => {
-        const cr = OtVar.Create.ValueFactory();
+        const cr = new OtVar.ValueFactory();
         const ivs = createVS();
         const inter = new MockInterpreter(ivs);
         inter.operand(1, 2, 3, 4, 2).operator(CffOperator.Blend);
@@ -81,7 +81,7 @@ describe("CFF Interpreter", () => {
     });
 
     test("Should handle VSIndex", () => {
-        const cr = OtVar.Create.ValueFactory();
+        const cr = new OtVar.ValueFactory();
         const ivs = createVS();
         const inter = new MockInterpreter(ivs);
         inter.operand(2).operator(CffOperator.VsIndex);
@@ -94,7 +94,7 @@ describe("CFF Interpreter", () => {
     });
 
     test("Should handle blend chaining", () => {
-        const cr = OtVar.Create.ValueFactory();
+        const cr = new OtVar.ValueFactory();
         const ivs = createVS();
         const inter = new MockInterpreter(ivs);
         inter.operand(2).operator(CffOperator.VsIndex);

--- a/packages/io-bin-glyph-store/src/cff/metric.test.ts
+++ b/packages/io-bin-glyph-store/src/cff/metric.test.ts
@@ -24,9 +24,9 @@ test("CFF metric variation test, WidthAndVWidthVF.otf", () => {
     const { glyphs, fvar } = readCff("WidthAndVWidthVF.otf");
     const gid1 = glyphs.items[1];
     const [wdth, vwid] = fvar!.axes;
-    const narrow = OtVar.Create.Master([{ dim: wdth.dim, min: -1, peak: -1, max: 0 }]);
-    const short = OtVar.Create.Master([{ dim: vwid.dim, min: -1, peak: -1, max: 0 }]);
-    const cr = OtVar.Create.ValueFactory();
+    const narrow = new OtVar.Master([{ dim: wdth.dim, min: -1, peak: -1, max: 0 }]);
+    const short = new OtVar.Master([{ dim: vwid.dim, min: -1, peak: -1, max: 0 }]);
+    const cr = new OtVar.ValueFactory();
     expect(OtVar.Ops.equal(gid1.vertical.start, cr.make(1100, [short, -440]))).toBe(true);
     expect(OtVar.Ops.equal(gid1.vertical.end, cr.make(-150, [short, +60]))).toBe(true);
     expect(OtVar.Ops.equal(gid1.horizontal.end, cr.make(750, [narrow, -300]))).toBe(true);

--- a/packages/io-bin-glyph-store/src/ttf/metric.test.ts
+++ b/packages/io-bin-glyph-store/src/ttf/metric.test.ts
@@ -24,9 +24,9 @@ test("TTF metric variation test, WidthAndVWidthVF.ttf", () => {
     const { glyphs, fvar } = readTtf("WidthAndVWidthVF.ttf");
     const gid1 = glyphs.items[1];
     const [wdth, vwid] = fvar!.axes;
-    const narrow = OtVar.Create.Master([{ dim: wdth.dim, min: -1, peak: -1, max: 0 }]);
-    const short = OtVar.Create.Master([{ dim: vwid.dim, min: -1, peak: -1, max: 0 }]);
-    const cr = OtVar.Create.ValueFactory();
+    const narrow = new OtVar.Master([{ dim: wdth.dim, min: -1, peak: -1, max: 0 }]);
+    const short = new OtVar.Master([{ dim: vwid.dim, min: -1, peak: -1, max: 0 }]);
+    const cr = new OtVar.ValueFactory();
     expect(OtVar.Ops.equal(gid1.vertical.start, cr.make(1100, [short, -440]))).toBe(true);
     expect(OtVar.Ops.equal(gid1.vertical.end, cr.make(-150, [short, +60]))).toBe(true);
     expect(OtVar.Ops.equal(gid1.horizontal.end, cr.make(750, [narrow, -300]))).toBe(true);

--- a/packages/io-bin-layout/src/base/index.ts
+++ b/packages/io-bin-layout/src/base/index.ts
@@ -39,7 +39,7 @@ export const BaseTableIo = {
         designSpace?: Data.Maybe<OtVar.DesignSpace>
     ) {
         const ivs: null | WriteTimeIVS = designSpace
-            ? WriteTimeIVS.create(OtVar.Create.MasterSet())
+            ? WriteTimeIVS.create(new OtVar.MasterSet())
             : null;
         frag.uint16(1);
         const hMinorVersion = frag.reserve(UInt16);

--- a/packages/io-bin-layout/src/gdef/write.test.ts
+++ b/packages/io-bin-layout/src/gdef/write.test.ts
@@ -26,7 +26,7 @@ describe("GDEF write", () => {
             designSpace
         );
 
-        const ivsW = WriteTimeIVS.create(OtVar.Create.MasterSet());
+        const ivsW = WriteTimeIVS.create(new OtVar.MasterSet());
         const gdefBuf = Frag.pack(Frag.from(GdefTableIo, gdefDat.gdef, gOrd, ivsW, designSpace));
 
         const gdefDat2 = new BinaryView(gdefBuf).next(GdefTableIo, gOrd, designSpace);

--- a/packages/io-bin-layout/src/lookups/test/-shared-test-util.test.ts
+++ b/packages/io-bin-layout/src/lookups/test/-shared-test-util.test.ts
@@ -78,12 +78,12 @@ export function SetupVariation() {
     ];
     const [wght, wdth] = ds;
     const masters = {
-        bold: OtVar.Create.Master([{ dim: wght, min: 0, peak: 1, max: 1 }]),
-        wide: OtVar.Create.Master([{ dim: wdth, min: 0, peak: 1, max: 1 }])
+        bold: new OtVar.Master([{ dim: wght, min: 0, peak: 1, max: 1 }]),
+        wide: new OtVar.Master([{ dim: wdth, min: 0, peak: 1, max: 1 }])
     };
-    const ms = OtVar.Create.MasterSet();
+    const ms = new OtVar.MasterSet();
     const ivs = WriteTimeIVS.create(ms);
-    const cr = OtVar.Create.ValueFactory(ms);
+    const cr = new OtVar.ValueFactory(ms);
     const create = (...xs: (number | [OtVar.Master, number])[]) => cr.make(...xs);
     return { designSpace: ds, masters, ivs, masterSet: ms, create };
 }

--- a/packages/io-bin-layout/src/main/write.ts
+++ b/packages/io-bin-layout/src/main/write.ts
@@ -25,7 +25,7 @@ export function writeOtl(
 ) {
     let { gsub, gpos, gdef } = otl;
     const designSpace = md.fvar ? md.fvar.getDesignSpace() : null;
-    const ivs = md.fvar ? WriteTimeIVS.create(OtVar.Create.MasterSet()) : null;
+    const ivs = md.fvar ? WriteTimeIVS.create(new OtVar.MasterSet()) : null;
     if (ivs && !gdef) gdef = new Gdef.Table();
     const stat = md.os2 ? new Os2Stat(md.os2) : new EmptyStat();
 

--- a/packages/io-bin-metadata/src/mvar/index.ts
+++ b/packages/io-bin-metadata/src/mvar/index.ts
@@ -130,7 +130,7 @@ export const MvarTableIo = {
         md: OtFontMetadata,
         afEmpty?: ImpLib.Access<boolean>
     ) {
-        const ivs = WriteTimeIVS.create(OtVar.Create.MasterSet());
+        const ivs = WriteTimeIVS.create(new OtVar.MasterSet());
         const lenses = new Map(lensSourcesFromMd(md));
         const rec: [string, number, number][] = [];
         for (const [tag, lens] of lenses) {

--- a/packages/io-bin-metric/src/metric-variance.ts
+++ b/packages/io-bin-metric/src/metric-variance.ts
@@ -138,9 +138,9 @@ export const MetricVarianceIo = {
             if (!designSpace.length) throw Errors.Variation.NoAxes();
             Assert.NoGap("HVAR/VVAR measures", mv.measures);
 
-            const ms = OtVar.Create.MasterSet();
+            const ms = new OtVar.MasterSet();
             const ivs = WriteTimeIVS.create(ms);
-            const mFallback = OtVar.Create.Master([
+            const mFallback = new OtVar.Master([
                 {
                     dim: designSpace.at(0),
                     min: 0,

--- a/packages/io-bin-ttf/src/cvar/index.ts
+++ b/packages/io-bin-ttf/src/cvar/index.ts
@@ -49,7 +49,7 @@ export const CvarIo = {
 
 class CvtTvhClient implements TupleVariationGeometryClient {
     constructor(cvt: Cvt.Table) {
-        const ms = OtVar.Create.MasterSet();
+        const ms = new OtVar.MasterSet();
         this.contours = this.createContours(ms, cvt);
     }
 

--- a/packages/io-bin-ttf/src/gvar/read.test.ts
+++ b/packages/io-bin-ttf/src/gvar/read.test.ts
@@ -35,9 +35,9 @@ test("Reading : TTF, variable", () => {
         {},
         fvar!.getDesignSpace()
     );
-    const thin = OtVar.Create.Master([{ dim: fvar!.axes[0].dim, min: -1, peak: -1, max: 0 }]);
-    const bold = OtVar.Create.Master([{ dim: fvar!.axes[0].dim, min: 0, peak: +1, max: +1 }]);
-    const cr = OtVar.Create.ValueFactory();
+    const thin = new OtVar.Master([{ dim: fvar!.axes[0].dim, min: -1, peak: -1, max: 0 }]);
+    const bold = new OtVar.Master([{ dim: fvar!.axes[0].dim, min: 0, peak: +1, max: +1 }]);
+    const cr = new OtVar.ValueFactory();
     rectifyGlyphOrder(gOrd);
     {
         const notDef = gOrd.at(0);

--- a/packages/io-bin-ttf/src/gvar/read.ts
+++ b/packages/io-bin-ttf/src/gvar/read.ts
@@ -29,7 +29,7 @@ export const GvarTableRead = Read(
         designSpace: OtVar.DesignSpace
     ) => {
         const header = view.next(GvarHeader, gOrd, cfg, designSpace);
-        const ms = OtVar.Create.MasterSet();
+        const ms = new OtVar.MasterSet();
 
         for (let gid = 0; gid < gOrd.length; gid++) {
             const glyph = gOrd.at(gid);

--- a/packages/io-bin-ttf/src/shared/tvd-access.ts
+++ b/packages/io-bin-ttf/src/shared/tvd-access.ts
@@ -2,7 +2,7 @@ import { OtVar } from "@ot-builder/variance";
 
 export abstract class CumulativeTvd {
     constructor(ms: OtVar.MasterSet) {
-        this.valueCreator = OtVar.Create.ValueFactory(ms);
+        this.valueCreator = new OtVar.ValueFactory(ms);
     }
     private valueCreator: OtVar.ValueFactory;
     private pending: [OtVar.Master, number][] = [];

--- a/packages/var-store/src/ivs/bin-io.test.ts
+++ b/packages/var-store/src/ivs/bin-io.test.ts
@@ -6,22 +6,22 @@ import { ReadTimeIVS, WriteTimeIVS } from "./impl";
 
 const Wght = new OtVar.Dim("wght", 100, 400, 900);
 const Wdth = new OtVar.Dim("wdth", 25, 100, 200);
-const Bold = OtVar.Create.Master([
+const Bold = new OtVar.Master([
     { dim: Wght, min: 0, peak: 1, max: 1 },
     { dim: Wdth, min: -1, peak: 0, max: 1 }
 ]);
-const Wide = OtVar.Create.Master([
+const Wide = new OtVar.Master([
     { dim: Wght, min: -1, peak: 0, max: 1 },
     { dim: Wdth, min: 0, peak: 1, max: 1 }
 ]);
-const Corner = OtVar.Create.Master([
+const Corner = new OtVar.Master([
     { dim: Wght, min: 0, peak: 1, max: 1 },
     { dim: Wdth, min: 0, peak: 1, max: 1 }
 ]);
 
 test("IVS roundtrip -- Traditional", () => {
-    const mc = OtVar.Create.MasterSet();
-    const cr = OtVar.Create.ValueFactory(mc);
+    const mc = new OtVar.MasterSet();
+    const cr = new OtVar.ValueFactory(mc);
     const ivs = WriteTimeIVS.create(mc);
     ivs.valueToInnerOuterID(cr.make(100, [Bold, 150], [Wide, 100]));
     ivs.valueToInnerOuterID(cr.make(100, [Bold, 150], [Wide, 200]));
@@ -46,8 +46,8 @@ test("IVS roundtrip -- Traditional", () => {
 });
 
 test("IVS roundtrip -- Master only (CFF2-ish)", () => {
-    const mc = OtVar.Create.MasterSet();
-    const cr = OtVar.Create.ValueFactory(mc);
+    const mc = new OtVar.MasterSet();
+    const cr = new OtVar.ValueFactory(mc);
     const ivs = WriteTimeIVS.create(mc);
     const col = ivs.createCollector();
     col.collect(cr.make(100, [Bold, 150], [Wide, 100]));

--- a/packages/var-store/src/ivs/impl.ts
+++ b/packages/var-store/src/ivs/impl.ts
@@ -31,7 +31,7 @@ const RegionList = {
                 const max = pAxis.next(F2D14);
                 spans.push({ dim: designSpace.at(axisIndex), min, peak, max });
             }
-            ivs.knownMasters.push(OtVar.Create.Master(spans));
+            ivs.knownMasters.push(new OtVar.Master(spans));
         }
     }),
     ...Write((fr, regions: ReadonlyArray<OtVar.Master>, ds: OtVar.DesignSpace) => {
@@ -40,7 +40,7 @@ const RegionList = {
         for (const region of ImpLib.Iterators.ToCount(
             regions,
             regions.length,
-            OtVar.Create.Master([])
+            new OtVar.Master([])
         )) {
             const m: Map<OtVar.Dim, OtVar.MasterDim> = new Map();
             for (const dim of region.regions) {
@@ -56,7 +56,7 @@ const RegionList = {
 
 const IVD = {
     ...Read(vw => {
-        const ivd = new ReadTimeIVD(OtVar.Create.ValueFactory(OtVar.Create.MasterSet()));
+        const ivd = new ReadTimeIVD(new OtVar.ValueFactory(new OtVar.MasterSet()));
         const itemCount = vw.uint16();
         const shortDeltaCount = vw.uint16();
         const regionIndexCount = vw.uint16();

--- a/packages/var-store/src/ivs/store.test.ts
+++ b/packages/var-store/src/ivs/store.test.ts
@@ -4,30 +4,30 @@ import { WriteTimeIVS } from "./impl";
 
 const Wght = new OtVar.Dim("wght", 100, 400, 900);
 const Wdth = new OtVar.Dim("wdth", 25, 100, 200);
-const Bold = OtVar.Create.Master([
+const Bold = new OtVar.Master([
     { dim: Wght, min: 0, peak: 1, max: 1 },
     { dim: Wdth, min: -1, peak: 0, max: 1 }
 ]);
-const Bold1 = OtVar.Create.Master([
+const Bold1 = new OtVar.Master([
     { dim: Wght, min: 0, peak: 1, max: 1 },
     { dim: Wdth, min: -1, peak: 0, max: 1 }
 ]);
-const Bold2 = OtVar.Create.Master([
+const Bold2 = new OtVar.Master([
     { dim: Wdth, min: -1, peak: 0, max: 1 },
     { dim: Wght, min: 0, peak: 1, max: 1 }
 ]);
-const Wide = OtVar.Create.Master([
+const Wide = new OtVar.Master([
     { dim: Wght, min: -1, peak: 0, max: 1 },
     { dim: Wdth, min: 0, peak: 1, max: 1 }
 ]);
-const Corner = OtVar.Create.Master([
+const Corner = new OtVar.Master([
     { dim: Wght, min: 0, peak: 1, max: 1 },
     { dim: Wdth, min: 0, peak: 1, max: 1 }
 ]);
 
 test("Write time IVS : Value management", () => {
-    const mc = OtVar.Create.MasterSet();
-    const cr = OtVar.Create.ValueFactory(mc);
+    const mc = new OtVar.MasterSet();
+    const cr = new OtVar.ValueFactory(mc);
     const ivs = WriteTimeIVS.create(mc);
 
     expect({ outer: 0, inner: 0 }).toEqual(
@@ -56,8 +56,8 @@ test("Write time IVS : Value management", () => {
 });
 
 test("Write time IVS : Value management with overflow", () => {
-    const mc = OtVar.Create.MasterSet();
-    const cr = OtVar.Create.ValueFactory(mc);
+    const mc = new OtVar.MasterSet();
+    const cr = new OtVar.ValueFactory(mc);
     const ivs = WriteTimeIVS.create(mc);
 
     for (let p = 0; p < 0x100; p++) {
@@ -72,8 +72,8 @@ test("Write time IVS : Value management with overflow", () => {
 });
 
 test("Write time IVS : Master-only management (CFF2-ish)", () => {
-    const mc = OtVar.Create.MasterSet();
-    const cr = OtVar.Create.ValueFactory(mc);
+    const mc = new OtVar.MasterSet();
+    const cr = new OtVar.ValueFactory(mc);
     const ivs = WriteTimeIVS.create(mc);
     const col = ivs.createCollector();
     const d1 = col.collect(cr.make(100, [Bold, 150], [Wide, 100]));

--- a/packages/var-store/src/tvs/read/index.ts
+++ b/packages/var-store/src/tvs/read/index.ts
@@ -100,7 +100,7 @@ const TupleVariationHeader = Read((view: BinaryView, vsr: TupleVariationSource) 
         dims.push(mDim);
     }
     return {
-        master: OtVar.Create.Master(dims),
+        master: new OtVar.Master(dims),
         variationDataSize,
         hasPrivatePoints: !!(_tupleIndex & TvhFlags.PRIVATE_POINT_NUMBERS)
     };

--- a/packages/var-store/src/tvs/write/collect.ts
+++ b/packages/var-store/src/tvs/write/collect.ts
@@ -10,7 +10,7 @@ export class TvsCollector extends DelayValueCollector<
     DelayDeltaValue
 > {
     constructor() {
-        super(OtVar.Ops, OtVar.Create.MasterSet());
+        super(OtVar.Ops, new OtVar.MasterSet());
     }
 
     protected createCollectedValue(origin: number, deltaMA: number[]) {

--- a/packages/variance/src/otvar-impl/index.ts
+++ b/packages/variance/src/otvar-impl/index.ts
@@ -2,34 +2,29 @@ import { Data } from "@ot-builder/prelude";
 
 import { VarianceDim as Dim } from "../interface/dimension";
 import { VarianceInstance } from "../interface/instance";
-import { VarianceMasterSet } from "../interface/master";
-import { VariableCreator, VariableOps } from "../interface/value";
 
 import { OtVarMaster, OtVarMasterDim } from "./master";
 import { OtVarMasterSet } from "./master-set";
-import { OtVarCreatorImpl, OtVarOps, OtVarValue } from "./ops";
-
-export { VarianceDim as Dim } from "../interface/dimension";
+import { OtVarValueFactory } from "./ops";
 
 // Type exports
 export type DesignSpace = Data.Order<Dim>;
-export type MasterDim = OtVarMasterDim<Dim>;
-export type Master = OtVarMaster<Dim>;
 export type Instance = VarianceInstance<Dim>;
-export type Value = OtVarValue<Dim, Master>;
-export type MasterSet = VarianceMasterSet<Dim, Master>;
-export type Ops = VariableOps<Dim, Master, Value>;
-export type ValueFactory = VariableCreator<Dim, Master, Value>;
-// Factory exports
-export const Ops = OtVarOps;
+export { VarianceDim as Dim } from "../interface/dimension";
+export { OtVarMaster as Master, OtVarMasterDim as MasterDim } from "./master";
+export { OtVarMasterSet as MasterSet } from "./master-set";
+export { OtVarOps as Ops, OtVarValueFactory as ValueFactory } from "./ops";
+export { OtVarValue as Value } from "./value";
+
+// [DEPRECATED] Kept for compatibility
 export namespace Create {
-    export function Master(init: Iterable<null | undefined | OtVarMasterDim<Dim>>): Master {
+    export function Master(init: Iterable<null | undefined | OtVarMasterDim>): OtVarMaster {
         return new OtVarMaster(init);
     }
-    export function MasterSet(): MasterSet {
-        return new OtVarMasterSet<Dim>();
+    export function MasterSet(): OtVarMasterSet {
+        return new OtVarMasterSet();
     }
-    export function ValueFactory(ms?: MasterSet): ValueFactory {
-        return new OtVarCreatorImpl(ms || MasterSet(), OtVarOps);
+    export function ValueFactory(ms?: OtVarMasterSet): OtVarValueFactory {
+        return new OtVarValueFactory(ms || MasterSet());
     }
 }

--- a/packages/variance/src/otvar-impl/master-set.ts
+++ b/packages/variance/src/otvar-impl/master-set.ts
@@ -7,30 +7,29 @@ import { OtVarMaster } from "./master";
 
 type VRStep = [number, number, number];
 
-type VRCRecord<A extends VarianceDim> = {
-    readonly master: OtVarMaster<A>;
+type VRCRecord = {
+    readonly master: OtVarMaster;
     readonly index: number;
 };
 
-export class OtVarMasterSet<A extends VarianceDim>
-    implements VarianceMasterSet<A, OtVarMaster<A>> {
+export class OtVarMasterSet implements VarianceMasterSet<VarianceDim, OtVarMaster> {
     private nAxes: number = 0;
-    private axisMap: WeakMap<A, number> = new WeakMap();
+    private axisMap: WeakMap<VarianceDim, number> = new WeakMap();
 
-    private masterList: VRCRecord<A>[] = [];
-    private masterMap = new ImpLib.PathMapImpl<number, VRCRecord<A>>();
-    private masterMapCache = new WeakMap<OtVarMaster<A>, VRCRecord<A>>();
+    private masterList: VRCRecord[] = [];
+    private masterMap = new ImpLib.PathMapImpl<number, VRCRecord>();
+    private masterMapCache = new WeakMap<OtVarMaster, VRCRecord>();
 
     constructor() {}
 
-    private putAxis(a: A) {
+    private putAxis(a: VarianceDim) {
         const axisIndex = this.axisMap.get(a);
         if (axisIndex) return axisIndex;
         this.nAxes += 1;
         this.axisMap.set(a, this.nAxes);
         return this.nAxes;
     }
-    private getStepNumbers(master: OtVarMaster<A>) {
+    private getStepNumbers(master: OtVarMaster) {
         const steps: (undefined | VRStep)[] = [];
         for (const region of master.regions) {
             const aid = this.putAxis(region.dim);
@@ -44,14 +43,14 @@ export class OtVarMasterSet<A extends VarianceDim>
         return stepNumbers;
     }
 
-    private getImpl(master: OtVarMaster<A>) {
+    private getImpl(master: OtVarMaster) {
         const stepNumbers = this.getStepNumbers(master);
         const lens = this.masterMap.createLens();
         lens.focus(stepNumbers);
 
         return lens.get();
     }
-    private getOrPutImpl(master: OtVarMaster<A>) {
+    private getOrPutImpl(master: OtVarMaster) {
         const stepNumbers = this.getStepNumbers(master);
         const lens = this.masterMap.createLens();
         lens.focus(stepNumbers);
@@ -65,11 +64,11 @@ export class OtVarMasterSet<A extends VarianceDim>
         return record;
     }
 
-    public get(master: OtVarMaster<A>) {
+    public get(master: OtVarMaster) {
         if (master.isInvalid()) return undefined;
         else return this.getImpl(master);
     }
-    public getOrPush(master: OtVarMaster<A>) {
+    public getOrPush(master: OtVarMaster) {
         if (master.isInvalid()) {
             return undefined;
         } else {
@@ -84,7 +83,7 @@ export class OtVarMasterSet<A extends VarianceDim>
     get size() {
         return this.masterList.length;
     }
-    public *[Symbol.iterator](): IterableIterator<[OtVarMaster<A>, number]> {
+    public *[Symbol.iterator](): IterableIterator<[OtVarMaster, number]> {
         for (const item of this.masterList) yield [item.master, item.index];
     }
 }

--- a/packages/variance/src/otvar-impl/master.ts
+++ b/packages/variance/src/otvar-impl/master.ts
@@ -2,20 +2,20 @@ import { VarianceDim } from "../interface/dimension";
 import { VarianceInstance, VarianceInstanceTupleW } from "../interface/instance";
 import { VarianceMaster } from "../interface/master";
 
-export interface OtVarMasterDim<A extends VarianceDim> {
-    readonly dim: A;
+export type OtVarMasterDim = {
+    readonly dim: VarianceDim;
     readonly min: number;
     readonly peak: number;
     readonly max: number;
-}
+};
 
-function axisRegionIsInvalid<A extends VarianceDim>(ar: OtVarMasterDim<A>) {
+function axisRegionIsInvalid<A extends VarianceDim>(ar: OtVarMasterDim) {
     return ar.min > ar.peak || ar.peak > ar.max || (ar.min < 0 && ar.max > 0 && ar.peak !== 0);
 }
-function axisRegionIsNeutral<A extends VarianceDim>(ar: OtVarMasterDim<A>) {
+function axisRegionIsNeutral<A extends VarianceDim>(ar: OtVarMasterDim) {
     return axisRegionIsInvalid(ar) || ar.peak === 0;
 }
-function axisRegionIsSimple<A extends VarianceDim>(ar: OtVarMasterDim<A>) {
+function axisRegionIsSimple<A extends VarianceDim>(ar: OtVarMasterDim) {
     return (
         axisRegionIsNeutral(ar) ||
         (ar.peak > 0 && ar.max === ar.peak && ar.min === 0) ||
@@ -23,7 +23,7 @@ function axisRegionIsSimple<A extends VarianceDim>(ar: OtVarMasterDim<A>) {
     );
 }
 
-function evaluateAxis<A extends VarianceDim>(ar: OtVarMasterDim<A>, instanceCoordinate: number) {
+function evaluateAxis(ar: OtVarMasterDim, instanceCoordinate: number) {
     if (axisRegionIsInvalid(ar)) return 1;
     else if (ar.peak === 0) return 1;
     else if (instanceCoordinate < ar.min || instanceCoordinate > ar.max) return 0;
@@ -35,11 +35,11 @@ function evaluateAxis<A extends VarianceDim>(ar: OtVarMasterDim<A>, instanceCoor
     }
 }
 
-export class OtVarMaster<A extends VarianceDim> implements VarianceMaster<A> {
-    public readonly regions: readonly OtVarMasterDim<A>[];
+export class OtVarMaster implements VarianceMaster<VarianceDim> {
+    public readonly regions: readonly OtVarMasterDim[];
 
-    constructor(init: Iterable<null | undefined | OtVarMasterDim<A>>) {
-        const regions: OtVarMasterDim<A>[] = [];
+    constructor(init: Iterable<null | undefined | OtVarMasterDim>) {
+        const regions: OtVarMasterDim[] = [];
         for (const r of init) if (r) regions.push(r);
         this.regions = regions;
     }
@@ -48,7 +48,7 @@ export class OtVarMaster<A extends VarianceDim> implements VarianceMaster<A> {
      * Return the peak instance
      */
     public getPeak() {
-        const inst: VarianceInstanceTupleW<A> = new Map();
+        const inst: VarianceInstanceTupleW<VarianceDim> = new Map();
         for (const ar of this.regions) {
             inst.set(ar.dim, ar.peak);
         }
@@ -60,7 +60,7 @@ export class OtVarMaster<A extends VarianceDim> implements VarianceMaster<A> {
      * If the master is invalid always return 0
      * @param instance instance to weight
      */
-    public evaluate(instance: VarianceInstance<A>) {
+    public evaluate(instance: VarianceInstance<VarianceDim>) {
         if (this.isInvalid()) return 0;
         let w = 1;
         for (const ar of this.regions) {

--- a/packages/variance/src/otvar-impl/ops.ts
+++ b/packages/variance/src/otvar-impl/ops.ts
@@ -1,49 +1,29 @@
-import { Algebra } from "@ot-builder/prelude";
-
 import { VarianceDim } from "../interface/dimension";
 import { VarianceInstance } from "../interface/instance";
-import { VarianceMaster, VarianceMasterSet } from "../interface/master";
 import { VariableCreator, VariableOps } from "../interface/value";
 
 import { OtVarMaster } from "./master";
 import { OtVarMasterSet } from "./master-set";
-import { OtVarValueC } from "./value";
+import { OtVarValue, OtVarValueC } from "./value";
 
-export type OtVarValue<A extends VarianceDim, M extends VarianceMaster<A>> =
-    | number
-    | OtVarValueC<A, M>;
-
-type MasterSetFactory<
-    A extends VarianceDim,
-    M extends VarianceMaster<A>
-> = () => VarianceMasterSet<A, M>;
-
-export class OtVarCreatorImpl<A extends VarianceDim, M extends VarianceMaster<A>>
-    implements VariableCreator<A, M, OtVarValue<A, M>> {
-    constructor(
-        public readonly masterSet: VarianceMasterSet<A, M>,
-        public ops: Algebra.VectorSpace<OtVarValue<A, M>, number>
-    ) {}
-
-    public create(origin: number = 0, variance: Iterable<[M, number]> = []) {
+export class OtVarValueFactory implements VariableCreator<VarianceDim, OtVarMaster, OtVarValue> {
+    constructor(public readonly masterSet: OtVarMasterSet = new OtVarMasterSet()) {}
+    public create(origin: number = 0, variance: Iterable<[OtVarMaster, number]> = []) {
         if (!variance) return origin;
         return OtVarValueC.Create(this.masterSet, origin, variance);
     }
-    public make(...xs: (OtVarValue<A, M> | [M, number])[]) {
-        let v: OtVarValue<A, M> = this.ops.neutral;
+    public make(...xs: (OtVarValue | [OtVarMaster, number])[]) {
+        let v: OtVarValue = OtVarOps.neutral;
         for (const x of xs) {
-            if (Array.isArray(x)) v = this.ops.add(v, this.create(0, [x]));
-            else v = this.ops.add(v, x);
+            if (Array.isArray(x)) v = OtVarOps.add(v, this.create(0, [x]));
+            else v = OtVarOps.add(v, x);
         }
         return v;
     }
 }
 
-class OrVarOpsImpl<A extends VarianceDim, M extends VarianceMaster<A>>
-    implements VariableOps<A, M, OtVarValue<A, M>> {
-    constructor(private readonly masterSetFactory: MasterSetFactory<A, M>) {}
-
-    protected scaleAdd(sa: number, a: OtVarValue<A, M>, sb: number, b: OtVarValue<A, M>) {
+class OrVarOpsImpl implements VariableOps<VarianceDim, OtVarMaster, OtVarValue> {
+    protected scaleAdd(sa: number, a: OtVarValue, sb: number, b: OtVarValue) {
         if (typeof a === "number") {
             if (typeof b === "number") {
                 return sa * a + sb * b;
@@ -60,38 +40,38 @@ class OrVarOpsImpl<A extends VarianceDim, M extends VarianceMaster<A>>
     }
 
     public readonly neutral = 0;
-    public add(a: OtVarValue<A, M>, b: OtVarValue<A, M>) {
+    public add(a: OtVarValue, b: OtVarValue) {
         return this.scaleAdd(1, a, 1, b);
     }
-    public minus(a: OtVarValue<A, M>, b: OtVarValue<A, M>) {
+    public minus(a: OtVarValue, b: OtVarValue) {
         return this.scaleAdd(1, a, -1, b);
     }
-    public negate(a: OtVarValue<A, M>) {
+    public negate(a: OtVarValue) {
         return this.scaleAdd(-1, a, 1, 0);
     }
-    public scale(s: number, a: OtVarValue<A, M>) {
+    public scale(s: number, a: OtVarValue) {
         return this.scaleAdd(s, a, 1, 0);
     }
-    public addScale(a: OtVarValue<A, M>, s: number, b: OtVarValue<A, M>) {
+    public addScale(a: OtVarValue, s: number, b: OtVarValue) {
         return this.scaleAdd(1, a, s, b);
     }
 
-    public originOf(a: OtVarValue<A, M>): number {
+    public originOf(a: OtVarValue): number {
         if (typeof a === "number") return a;
         else return a.origin;
     }
-    public varianceOf(a: OtVarValue<A, M>): Iterable<[M, number]> {
+    public varianceOf(a: OtVarValue): Iterable<[OtVarMaster, number]> {
         if (typeof a === "number") return [];
         else return a.variance();
     }
-    public removeOrigin(a: OtVarValue<A, M>): OtVarValue<A, M> {
+    public removeOrigin(a: OtVarValue): OtVarValue {
         return this.minus(a, this.originOf(a));
     }
-    public evaluate(a: OtVarValue<A, M>, instance: VarianceInstance<A>) {
+    public evaluate(a: OtVarValue, instance: VarianceInstance<VarianceDim>) {
         if (typeof a === "number") return a;
         else return a.evaluate(instance);
     }
-    public equal(a: OtVarValue<A, M>, b: OtVarValue<A, M>, err: number = 1) {
+    public equal(a: OtVarValue, b: OtVarValue, err: number = 1) {
         if (typeof a === "number" && typeof b === "number") return Math.abs(a - b) <= err;
         if (Math.abs(this.evaluate(a, null) - this.evaluate(b, null)) > err) return false;
         for (const [m, delta] of [...this.varianceOf(a), ...this.varianceOf(b)]) {
@@ -102,26 +82,22 @@ class OrVarOpsImpl<A extends VarianceDim, M extends VarianceMaster<A>>
         }
         return true;
     }
-    public sum(...xs: OtVarValue<A, M>[]) {
-        let s: OtVarValue<A, M> = 0;
+    public sum(...xs: OtVarValue[]) {
+        let s: OtVarValue = 0;
         for (const x of xs) s = this.add(s, x);
         return s;
     }
-    public isConstant(x: OtVarValue<A, M>) {
+    public isConstant(x: OtVarValue) {
         if (typeof x === "number") return true;
         return this.equal(x, this.originOf(x), 1 / 0x10000);
     }
-    public isZero(x: OtVarValue<A, M>) {
+    public isZero(x: OtVarValue) {
         return this.isConstant(x) && this.originOf(x) === 0;
     }
 
-    public Creator(ms?: VarianceMasterSet<A, M>) {
-        return new OtVarCreatorImpl(ms || this.masterSetFactory(), this);
+    public Creator(ms?: OtVarMasterSet) {
+        return new OtVarValueFactory(ms || new OtVarMasterSet());
     }
 }
 
-export const OtVarOps: VariableOps<
-    VarianceDim,
-    OtVarMaster<VarianceDim>,
-    OtVarValue<VarianceDim, OtVarMaster<VarianceDim>>
-> = new OrVarOpsImpl(() => new OtVarMasterSet());
+export const OtVarOps: VariableOps<VarianceDim, OtVarMaster, OtVarValue> = new OrVarOpsImpl();


### PR DESCRIPTION
This simplifies `Ot.Var` implementation code, since these polymorphism inside it is really unnecessary.