### PR TITLE
TTF: Always set overlapping flags

### DIFF
--- a/change/@ot-builder-cli-proc-2020-07-11-08-45-16-always-set-overlapping-flags.json
+++ b/change/@ot-builder-cli-proc-2020-07-11-08-45-16-always-set-overlapping-flags.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TTF: Always set overlapping flags",
+  "packageName": "@ot-builder/cli-proc",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-07-11T15:45:15.865Z"
+}

--- a/change/@ot-builder-io-bin-ttf-2020-07-11-08-45-16-always-set-overlapping-flags.json
+++ b/change/@ot-builder-io-bin-ttf-2020-07-11-08-45-16-always-set-overlapping-flags.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TTF: Always set overlapping flags",
+  "packageName": "@ot-builder/io-bin-ttf",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-07-11T15:45:16.619Z"
+}

--- a/change/@ot-builder-ot-glyphs-2020-07-11-08-45-16-always-set-overlapping-flags.json
+++ b/change/@ot-builder-ot-glyphs-2020-07-11-08-45-16-always-set-overlapping-flags.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TTF: Always set overlapping flags",
+  "packageName": "@ot-builder/ot-glyphs",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-07-11T15:45:16.685Z"
+}

--- a/change/@ot-builder-rectify-2020-07-11-08-45-16-always-set-overlapping-flags.json
+++ b/change/@ot-builder-rectify-2020-07-11-08-45-16-always-set-overlapping-flags.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TTF: Always set overlapping flags",
+  "packageName": "@ot-builder/rectify",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch",
+  "date": "2020-07-11T15:45:16.750Z"
+}

--- a/doc/pages/references/ot/glyph.mdx
+++ b/doc/pages/references/ot/glyph.mdx
@@ -185,10 +185,6 @@ Defines as the union of the following cases.
 
     If set, this forces the advance width and left sidebearing for the composite to be equal to those from this original glyph. This works for hinted and unhinted characters.
 
- * <Member s={Ot.Glyph.TtReferenceProps.overlapCompound} type={boolean} />
-
-    If set, the components of the glyph containing this reference overlap.
-
  * <Member s={Ot.Glyph.TtReferenceProps.pointAttachment} type={Data.Maybe(Ot.Glyph.PointAttachment)} />
 
     When present, this reference follows TrueType's point-attachment rules.

--- a/packages/cli-proc/src/support/share-glyph-set/glyph-hasher.ts
+++ b/packages/cli-proc/src/support/share-glyph-set/glyph-hasher.ts
@@ -137,12 +137,7 @@ class HashGeometry {
         hr.number(ref.transform.xx, ref.transform.xy, ref.transform.yx, ref.transform.yy);
         hr.numbers(this.vp.toArrayRep(ref.transform.dx));
         hr.numbers(this.vp.toArrayRep(ref.transform.dy));
-        hr.flag(
-            !!ref.transform.scaledOffset,
-            !!ref.useMyMetrics,
-            !!ref.overlapCompound,
-            !!ref.pointAttachment
-        );
+        hr.flag(!!ref.transform.scaledOffset, !!ref.useMyMetrics, !!ref.pointAttachment);
         if (ref.pointAttachment) {
             hr.begin().number(
                 ref.pointAttachment.outer.pointIndex,

--- a/packages/io-bin-ttf/src/glyf/classifier.ts
+++ b/packages/io-bin-ttf/src/glyf/classifier.ts
@@ -82,7 +82,6 @@ class GeometryClassifier {
         const ref = new OtGlyph.TtReference(refProps.to, refProps.transform);
         ref.roundXyToGrid = refProps.roundXyToGrid;
         ref.useMyMetrics = refProps.useMyMetrics;
-        ref.overlapCompound = refProps.overlapCompound;
         ref.pointAttachment = refProps.pointAttachment;
         this.collectedReferences.push(ref);
     }

--- a/packages/io-bin-ttf/src/glyf/read.ts
+++ b/packages/io-bin-ttf/src/glyf/read.ts
@@ -183,7 +183,6 @@ const CompositeGlyph = Read((view, gOrd: Data.Order<OtGlyph>) => {
 
         ref.roundXyToGrid = !!(ComponentFlag.ROUND_XY_TO_GRID & flags);
         ref.useMyMetrics = !!(ComponentFlag.USE_MY_METRICS & flags);
-        ref.overlapCompound = !!(ComponentFlag.OVERLAP_COMPOUND & flags);
 
         if (ComponentFlag.ARGS_ARE_XY_VALUES & flags) {
             ref.transform = { ...ref.transform, dx: arg1, dy: arg2 };

--- a/packages/io-bin-ttf/src/gvar/read.ts
+++ b/packages/io-bin-ttf/src/gvar/read.ts
@@ -182,7 +182,6 @@ class TtReferenceHolder implements GeomHolder {
         const ref1 = new OtGlyph.TtReference(this.ref.to, this.ref.transform);
         ref1.roundXyToGrid = this.ref.roundXyToGrid;
         ref1.useMyMetrics = this.ref.useMyMetrics;
-        ref1.overlapCompound = this.ref.overlapCompound;
         ref1.pointAttachment = this.ref.pointAttachment;
         return ref1;
     }

--- a/packages/io-bin-ttf/src/rectify/rectify.ts
+++ b/packages/io-bin-ttf/src/rectify/rectify.ts
@@ -91,7 +91,6 @@ class AttachmentPointToCoordAlg {
             const geom = new OtGlyph.TtReference(ref.to, tfm);
             geom.roundXyToGrid = ref.roundXyToGrid;
             geom.useMyMetrics = ref.useMyMetrics;
-            geom.overlapCompound = ref.overlapCompound;
             geom.pointAttachment = ref.pointAttachment;
             for (const z of innerPoints) {
                 st.points.push(OtGlyph.PointOps.applyTransform(z, tfm));

--- a/packages/ot-glyphs/src/general-glyph/index.ts
+++ b/packages/ot-glyphs/src/general-glyph/index.ts
@@ -15,7 +15,6 @@ export namespace GeneralGlyph {
         transform: Transform2X3.T<X>;
         roundXyToGrid?: boolean;
         useMyMetrics?: boolean;
-        overlapCompound?: boolean;
         pointAttachment?: Data.Maybe<Lib_General_Point.PointAttachment>;
     }
     export interface GeometryListPropsT<E> {

--- a/packages/rectify/src/glyph/rectify-alg.ts
+++ b/packages/rectify/src/glyph/rectify-alg.ts
@@ -80,7 +80,6 @@ export class OtGhRectifyGeomPointAttachmentAlg {
             });
             ref1.roundXyToGrid = ref.roundXyToGrid;
             ref1.useMyMetrics = ref.useMyMetrics;
-            ref1.overlapCompound = ref.overlapCompound;
             ref1.pointAttachment = ref.pointAttachment;
             const innerPoints = RectifyImpl.getGlyphPoints(to1);
             this.processTtReferenceImpl(innerPoints, st, ref1);


### PR DESCRIPTION
This will enforce all systems to properly handle TT's non-zero fill rule.