### PR TITLE
GPOS: Fix mark filtering

### DIFF
--- a/change/@ot-builder-io-bin-layout-25e47f38-f826-4e86-861d-94ceb6cd7dc6.json
+++ b/change/@ot-builder-io-bin-layout-25e47f38-f826-4e86-861d-94ceb6cd7dc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "GPOS: Fix base filtering when writing mark-related lookups.",
+  "packageName": "@ot-builder/io-bin-layout",
+  "email": "belleve@typeof.net",
+  "dependentChangeType": "patch"
+}

--- a/packages/io-bin-layout/src/lookups/gpos-mark-write.ts
+++ b/packages/io-bin-layout/src/lookups/gpos-mark-write.ts
@@ -1,6 +1,4 @@
-import { Writable } from "stream";
-
-import { Frag, Write } from "@ot-builder/bin-util";
+import { Frag } from "@ot-builder/bin-util";
 import { OtGlyph } from "@ot-builder/ot-glyphs";
 import { Gpos } from "@ot-builder/ot-layout";
 import { Data } from "@ot-builder/prelude";


### PR DESCRIPTION
The current mark lookup writer keeps empty base records when writing. This change fixes this behavior and only keeps "substantial" records.