### PR TITLE
OTL: add trick to prevent contextual lookups from generation

### DIFF
--- a/change/@ot-builder-io-bin-font-2f8669ce-2dfa-4c23-a23b-6fe38f70c49b.json
+++ b/change/@ot-builder-io-bin-font-2f8669ce-2dfa-4c23-a23b-6fe38f70c49b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add AvoidUsingContextualLookup trick",
+  "packageName": "@ot-builder/io-bin-font",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ot-builder-io-bin-layout-3301ff4e-0753-4142-b8e5-c56d33a64e2a.json
+++ b/change/@ot-builder-io-bin-layout-3301ff4e-0753-4142-b8e5-c56d33a64e2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add AvoidUsingContextualLookup trick",
+  "packageName": "@ot-builder/io-bin-layout",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/doc/pages/references/font-io.mdx
+++ b/doc/pages/references/font-io.mdx
@@ -120,6 +120,7 @@ Creates a TTC file <R s="Buffer"/> form a <R s={FontIo.TableSliceCollection}/> a
         * `0x0002`: Force single substitution and single position lookups to form one single subtable;
         * `0x0004`: Force lookups to use flat (format 1) coverage table;
         * `0x0008`: Force lookups to use coverage tables and class-def tables with less items instead of smaller footprint;
+        * `0x0010`: Force contextual lookups to become chaining (could be used to workaround certain Apple shaping engine's bugs);
 
 * <Item optional s={FontIo.FontIoConfig.extPrivate}/>:
 

--- a/packages/io-bin-font/src/config.ts
+++ b/packages/io-bin-font/src/config.ts
@@ -47,3 +47,5 @@ export function createConfig(partial: FontIoConfig): FontIoCfgFinal {
         generateDummyDigitalSignature: !!partial.generateDummyDigitalSignature
     };
 }
+
+export { LookupWriteTrick } from "@ot-builder/io-bin-layout";

--- a/packages/io-bin-layout/src/cfg/index.ts
+++ b/packages/io-bin-layout/src/cfg/index.ts
@@ -2,7 +2,7 @@ import { GsubGpos } from "@ot-builder/ot-layout";
 
 export interface LayoutCfgProps {
     gdefWriteTrick?: number;
-    lookupWriteTricks?: Map<GsubGpos.LookupProp, number>;
+    lookupWriteTricks?: Map<GsubGpos.LookupProp, LookupWriteTrick>;
 }
 export interface LayoutCfg {
     layout: LayoutCfgProps;
@@ -12,3 +12,14 @@ export interface LayoutCfgPt {
 }
 
 export const DefaultLayoutProps: LayoutCfgProps = {};
+
+export enum LookupWriteTrick {
+    AvoidUseExtension = 0x0001,
+    AvoidBreakSubtable = 0x0002,
+    UseFlatCoverage = 0x0004,
+    UseFastCoverage = 0x0008,
+    AvoidUsingContextualLookup = 0x0010,
+
+    ContextualForceFormat3 = 0x10000,
+    ContextualForceFormat2 = 0x20000
+}

--- a/packages/io-bin-layout/src/gsub-gpos-shared/general.ts
+++ b/packages/io-bin-layout/src/gsub-gpos-shared/general.ts
@@ -3,6 +3,7 @@ import { OtGlyph } from "@ot-builder/ot-glyphs";
 import { Data } from "@ot-builder/prelude";
 import { ReadTimeIVS, WriteTimeIVS } from "@ot-builder/var-store";
 
+import { LookupWriteTrick } from "../cfg";
 import { OtlStat } from "../stat";
 
 export interface SubtableReadingContext<L> {
@@ -11,7 +12,7 @@ export interface SubtableReadingContext<L> {
     ivs: Data.Maybe<ReadTimeIVS>;
 }
 export interface SubtableWriteContext<L> {
-    trick: number;
+    trick: LookupWriteTrick;
     crossReferences: Data.Order<L>;
     gOrd: Data.Order<OtGlyph>;
     ivs: Data.Maybe<WriteTimeIVS>;
@@ -25,7 +26,7 @@ export interface LookupReader<L, C extends L> {
 
 export interface LookupWriter<L, C extends L> {
     canBeUsed(lookup: L): lookup is L & C;
-    getLookupType(lookup: C): number;
+    getLookupType(lookup: C, context: SubtableWriteContext<L>): number;
     getLookupTypeSymbol(lookup: C): symbol;
     createSubtableFragments(lookup: C, context: SubtableWriteContext<L>): Frag[];
 }
@@ -53,14 +54,4 @@ export enum LookupFlag {
     IgnoreMarks = 8,
     UseMarkFilteringSet = 0x0010,
     MarkAttachmentType = 0xff00
-}
-
-export enum SubtableWriteTrick {
-    AvoidUseExtension = 1,
-    AvoidBreakSubtable = 2,
-    UseFlatCoverage = 4,
-    UseFastCoverage = 8,
-
-    ChainingForceFormat3 = 0x10000,
-    ChainingForceFormat2 = 0x20000
 }

--- a/packages/io-bin-layout/src/gsub-gpos-shared/trick.ts
+++ b/packages/io-bin-layout/src/gsub-gpos-shared/trick.ts
@@ -1,9 +1,9 @@
 import { GsubGpos } from "@ot-builder/ot-layout";
 
-import { LayoutCfg } from "../cfg";
+import { LayoutCfg, LookupWriteTrick } from "../cfg";
 
 export function setLookupTricks<L>(table: GsubGpos.TableT<L>, cfg: LayoutCfg) {
-    const tricks: Map<L, number> = new Map();
+    const tricks: Map<L, LookupWriteTrick> = new Map();
     if (cfg.layout.lookupWriteTricks) {
         for (const lookup of table.lookups) {
             const userTrick = cfg.layout.lookupWriteTricks.get(lookup);

--- a/packages/io-bin-layout/src/gsub-gpos-shared/write-lookup-list.ts
+++ b/packages/io-bin-layout/src/gsub-gpos-shared/write-lookup-list.ts
@@ -7,15 +7,11 @@ import { Data } from "@ot-builder/prelude";
 import { UInt16, UInt32 } from "@ot-builder/primitive";
 import { WriteTimeIVS } from "@ot-builder/var-store";
 
+import { LookupWriteTrick } from "../cfg";
 import { EmptyStat, OtlStat } from "../stat";
 
 import { decideIgnoreFlags } from "./decide-ignore-flags";
-import {
-    LookupFlag,
-    LookupWriterFactory,
-    SubtableWriteContext,
-    SubtableWriteTrick
-} from "./general";
+import { LookupFlag, LookupWriterFactory, SubtableWriteContext } from "./general";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -23,7 +19,7 @@ export interface LookupWriteContext<L> {
     gOrd: Data.Order<OtGlyph>;
     gdef?: Data.Maybe<Gdef.Table>;
     ivs?: Data.Maybe<WriteTimeIVS>;
-    tricks?: Data.Maybe<Map<L, number>>;
+    tricks?: Data.Maybe<Map<L, LookupWriteTrick>>;
     stat?: Data.Maybe<OtlStat>;
 }
 
@@ -98,7 +94,7 @@ class LookupListWriter<L extends GsubGpos.LookupProp> {
             if (!writer.canBeUsed(lookup)) continue;
             const header: LookupHeader = {
                 origLookupType: writer.getLookupTypeSymbol(lookup),
-                lookupType: writer.getLookupType(lookup),
+                lookupType: writer.getLookupType(lookup, context),
                 flags,
                 markFilteringSet,
                 rank: this.getLookupRank(
@@ -115,8 +111,8 @@ class LookupListWriter<L extends GsubGpos.LookupProp> {
         }
     }
 
-    private getLookupRank(origType: symbol, isDependency: boolean, trick: number) {
-        const rankTrick = 16 * (trick & SubtableWriteTrick.AvoidUseExtension ? 1 : 2);
+    private getLookupRank(origType: symbol, isDependency: boolean, trick: LookupWriteTrick) {
+        const rankTrick = 16 * (trick & LookupWriteTrick.AvoidUseExtension ? 1 : 2);
         const rankType =
             origType === Gsub.LookupType.Reverse
                 ? 1

--- a/packages/io-bin-layout/src/lookups/gpos-single.ts
+++ b/packages/io-bin-layout/src/lookups/gpos-single.ts
@@ -3,13 +3,13 @@ import { Assert, Errors } from "@ot-builder/errors";
 import { Gpos, LayoutCommon } from "@ot-builder/ot-layout";
 import { UInt16 } from "@ot-builder/primitive";
 
+import { LookupWriteTrick } from "../cfg";
 import {
     LookupReader,
     LookupWriter,
     SubtableReadingContext,
     SubtableSizeLimit,
-    SubtableWriteContext,
-    SubtableWriteTrick
+    SubtableWriteContext
 } from "../gsub-gpos-shared/general";
 import { CovUtils, GidCoverage, MaxCovItemWords, Ptr16GidCoverage } from "../shared/coverage";
 import { GposAdjustment } from "../shared/gpos-adjust";
@@ -179,7 +179,7 @@ export class GposSingleWriter implements LookupWriter<Gpos.Lookup, Gpos.Single> 
     }
 
     public createSubtableFragments(lookup: Gpos.Single, ctx: SubtableWriteContext<Gpos.Lookup>) {
-        const singleLookup = !!(ctx.trick & SubtableWriteTrick.AvoidBreakSubtable);
+        const singleLookup = !!(ctx.trick & LookupWriteTrick.AvoidBreakSubtable);
         const st = new GsubSingleWriterState();
         for (const [from, to] of lookup.adjustments) {
             st.addRecord(ctx.gOrd.reverse(from), to, ctx);

--- a/packages/io-bin-layout/src/lookups/gsub-single.ts
+++ b/packages/io-bin-layout/src/lookups/gsub-single.ts
@@ -3,13 +3,13 @@ import { Assert, Errors } from "@ot-builder/errors";
 import { Gsub } from "@ot-builder/ot-layout";
 import { UInt16 } from "@ot-builder/primitive";
 
+import { LookupWriteTrick } from "../cfg";
 import {
     LookupReader,
     LookupWriter,
     SubtableReadingContext,
     SubtableSizeLimit,
-    SubtableWriteContext,
-    SubtableWriteTrick
+    SubtableWriteContext
 } from "../gsub-gpos-shared/general";
 import { CovUtils, GidCoverage, MaxCovItemWords, Ptr16GidCoverage } from "../shared/coverage";
 
@@ -147,7 +147,7 @@ export class GsubSingleWriter implements LookupWriter<Gsub.Lookup, Gsub.Single> 
     }
 
     public createSubtableFragments(lookup: Gsub.Single, ctx: SubtableWriteContext<Gsub.Lookup>) {
-        const singleLookup = !!(ctx.trick & SubtableWriteTrick.AvoidBreakSubtable);
+        const singleLookup = !!(ctx.trick & LookupWriteTrick.AvoidBreakSubtable);
         const st = new GsubSingleWriterState();
         for (const [from, to] of lookup.mapping) {
             st.addGidDiff(ctx.gOrd.reverse(from), ctx.gOrd.reverse(to));

--- a/packages/io-bin-layout/src/lookups/test/-shared-test-util.test.ts
+++ b/packages/io-bin-layout/src/lookups/test/-shared-test-util.test.ts
@@ -7,12 +7,8 @@ import { Disorder } from "@ot-builder/test-util";
 import { ReadTimeIVS, WriteTimeIVS } from "@ot-builder/var-store";
 import { OtVar } from "@ot-builder/variance";
 
-import {
-    LookupReader,
-    LookupWriter,
-    SubtableWriteContext,
-    SubtableWriteTrick
-} from "../../gsub-gpos-shared/general";
+import { LookupWriteTrick } from "../../cfg";
+import { LookupReader, LookupWriter, SubtableWriteContext } from "../../gsub-gpos-shared/general";
 import { EmptyStat } from "../../stat";
 
 export interface LookupRoundTripConfig<L, C extends L> {
@@ -31,8 +27,8 @@ export function LookupRoundTripTest<L, C extends L>(
 ) {
     LookupRoundTripTestImpl(expected, cfg);
     if (!cfg.trick) {
-        LookupRoundTripTestImpl(expected, { ...cfg, trick: SubtableWriteTrick.UseFastCoverage });
-        LookupRoundTripTestImpl(expected, { ...cfg, trick: SubtableWriteTrick.UseFlatCoverage });
+        LookupRoundTripTestImpl(expected, { ...cfg, trick: LookupWriteTrick.UseFastCoverage });
+        LookupRoundTripTestImpl(expected, { ...cfg, trick: LookupWriteTrick.UseFlatCoverage });
     }
 }
 
@@ -46,9 +42,9 @@ function LookupRoundTripTestImpl<L, C extends L>(expected: C, cfg: LookupRoundTr
         ivs: cfg.variation ? cfg.variation.ivs : null,
         stat: new EmptyStat()
     };
-    const buffers = writer.createSubtableFragments(expected, swc).map(frag => Frag.pack(frag));
 
-    const lt = writer.getLookupType(expected);
+    const lt = writer.getLookupType(expected, swc);
+    const buffers = writer.createSubtableFragments(expected, swc).map(frag => Frag.pack(frag));
 
     let ivsR: Data.Maybe<ReadTimeIVS> = null;
     if (cfg.variation) {

--- a/packages/io-bin-layout/src/lookups/test/contextual.test.ts
+++ b/packages/io-bin-layout/src/lookups/test/contextual.test.ts
@@ -3,7 +3,7 @@ import { OtListGlyphStoreFactory } from "@ot-builder/ot-glyphs";
 import { Gsub } from "@ot-builder/ot-layout";
 import { BimapCtx, LookupCtx, LookupIdentity } from "@ot-builder/test-util";
 
-import { SubtableWriteTrick } from "../../gsub-gpos-shared/general";
+import { LookupWriteTrick } from "../../cfg";
 import { GsubChainingReader, GsubContextualReader } from "../contextual-read";
 import { GsubChainingContextualWriter } from "../contextual-write";
 
@@ -35,6 +35,54 @@ test("GSUB/GPOS Contextual : Simple", () => {
         match: [TuGlyphSet(gOrd, 0), TuGlyphSet(gOrd, 1)],
         inputBegins: 0,
         inputEnds: 2,
+        applications: [
+            { at: 0, apply: lOrd.at(0) },
+            { at: 1, apply: lOrd.at(1) }
+        ]
+    });
+    lookup.rules.push({
+        match: [TuGlyphSet(gOrd, 0), TuGlyphSet(gOrd, 1), TuGlyphSet(gOrd, 2)],
+        inputBegins: 0,
+        inputEnds: 3,
+        applications: [
+            { at: 0, apply: lOrd.at(0) },
+            { at: 1, apply: lOrd.at(1) },
+            { at: 2, apply: lOrd.at(2) }
+        ]
+    });
+
+    LookupRoundTripTest(lookup, roundtripConfig);
+    LookupRoundTripTest(lookup, {
+        ...roundtripConfig,
+        trick: LookupWriteTrick.ContextualForceFormat2
+    });
+    LookupRoundTripTest(lookup, {
+        ...roundtripConfig,
+        trick: LookupWriteTrick.ContextualForceFormat3
+    });
+
+    LookupRoundTripTest(lookup, {
+        ...roundtripConfig,
+        trick: LookupWriteTrick.AvoidUsingContextualLookup
+    });
+    LookupRoundTripTest(lookup, {
+        ...roundtripConfig,
+        trick:
+            LookupWriteTrick.ContextualForceFormat2 | LookupWriteTrick.AvoidUsingContextualLookup
+    });
+    LookupRoundTripTest(lookup, {
+        ...roundtripConfig,
+        trick:
+            LookupWriteTrick.ContextualForceFormat3 | LookupWriteTrick.AvoidUsingContextualLookup
+    });
+});
+
+test("GSUB/GPOS Chaining : Simple", () => {
+    const lookup = new Gsub.Chaining();
+    lookup.rules.push({
+        match: [TuGlyphSet(gOrd, 0), TuGlyphSet(gOrd, 1)],
+        inputBegins: 0,
+        inputEnds: 2,
         applications: [{ at: 0, apply: lOrd.at(0) }]
     });
     lookup.rules.push({
@@ -46,16 +94,19 @@ test("GSUB/GPOS Contextual : Simple", () => {
         ],
         inputBegins: 1,
         inputEnds: 3,
-        applications: [{ at: 0, apply: lOrd.at(1) }]
+        applications: [
+            { at: 0, apply: lOrd.at(1) },
+            { at: 1, apply: lOrd.at(2) }
+        ]
     });
 
     LookupRoundTripTest(lookup, roundtripConfig);
     LookupRoundTripTest(lookup, {
         ...roundtripConfig,
-        trick: SubtableWriteTrick.ChainingForceFormat2
+        trick: LookupWriteTrick.ContextualForceFormat2
     });
     LookupRoundTripTest(lookup, {
         ...roundtripConfig,
-        trick: SubtableWriteTrick.ChainingForceFormat3
+        trick: LookupWriteTrick.ContextualForceFormat3
     });
 });

--- a/packages/io-bin-layout/src/lookups/test/gpos-single.test.ts
+++ b/packages/io-bin-layout/src/lookups/test/gpos-single.test.ts
@@ -2,7 +2,7 @@ import { OtListGlyphStoreFactory } from "@ot-builder/ot-glyphs";
 import { Gpos } from "@ot-builder/ot-layout";
 import { BimapCtx, Disorder, LookupIdentity } from "@ot-builder/test-util";
 
-import { SubtableWriteTrick } from "../../gsub-gpos-shared/general";
+import { LookupWriteTrick } from "../../cfg";
 import { GposSingleReader, GposSingleWriter } from "../gpos-single";
 
 import {
@@ -40,7 +40,7 @@ describe("GPOS single lookup handler", () => {
         LookupRoundTripTest(lookup, roundtripConfig);
         LookupRoundTripTest(lookup, {
             ...roundtripConfig,
-            trick: SubtableWriteTrick.AvoidBreakSubtable | SubtableWriteTrick.UseFlatCoverage
+            trick: LookupWriteTrick.AvoidBreakSubtable | LookupWriteTrick.UseFlatCoverage
         });
     });
     test("Very same", () => {
@@ -58,7 +58,7 @@ describe("GPOS single lookup handler", () => {
         LookupRoundTripTest(lookup, roundtripConfig);
         LookupRoundTripTest(lookup, {
             ...roundtripConfig,
-            trick: SubtableWriteTrick.AvoidBreakSubtable | SubtableWriteTrick.UseFlatCoverage
+            trick: LookupWriteTrick.AvoidBreakSubtable | LookupWriteTrick.UseFlatCoverage
         });
     });
     test("Variable", () => {

--- a/packages/io-bin-layout/src/lookups/test/gsub-single.test.ts
+++ b/packages/io-bin-layout/src/lookups/test/gsub-single.test.ts
@@ -2,7 +2,7 @@ import { OtListGlyphStoreFactory } from "@ot-builder/ot-glyphs";
 import { Gsub } from "@ot-builder/ot-layout";
 import { BimapCtx, Disorder, LookupIdentity } from "@ot-builder/test-util";
 
-import { SubtableWriteTrick } from "../../gsub-gpos-shared/general";
+import { LookupWriteTrick } from "../../cfg";
 import { GsubSingleReader, GsubSingleWriter } from "../gsub-single";
 
 import { LookupRoundTripConfig, LookupRoundTripTest } from "./-shared-test-util.test";
@@ -31,7 +31,7 @@ describe("GSUB single lookup handler", () => {
         LookupRoundTripTest(lookup, roundtripConfig);
         LookupRoundTripTest(lookup, {
             ...roundtripConfig,
-            trick: SubtableWriteTrick.AvoidBreakSubtable | SubtableWriteTrick.UseFlatCoverage
+            trick: LookupWriteTrick.AvoidBreakSubtable | LookupWriteTrick.UseFlatCoverage
         });
     });
     test("Unusual", () => {
@@ -44,7 +44,7 @@ describe("GSUB single lookup handler", () => {
         LookupRoundTripTest(lookup, roundtripConfig);
         LookupRoundTripTest(lookup, {
             ...roundtripConfig,
-            trick: SubtableWriteTrick.AvoidBreakSubtable | SubtableWriteTrick.UseFlatCoverage
+            trick: LookupWriteTrick.AvoidBreakSubtable | LookupWriteTrick.UseFlatCoverage
         });
     });
 });

--- a/packages/io-bin-layout/src/shared/class-def.ts
+++ b/packages/io-bin-layout/src/shared/class-def.ts
@@ -5,7 +5,7 @@ import { OtGlyph } from "@ot-builder/ot-glyphs";
 import { LayoutCommon } from "@ot-builder/ot-layout";
 import { Data } from "@ot-builder/prelude";
 
-import { SubtableWriteTrick } from "../gsub-gpos-shared/general";
+import { LookupWriteTrick } from "../cfg";
 
 export const MaxClsDefItemWords = 3;
 
@@ -110,7 +110,7 @@ export const GidClassDef = {
             frag.push(OtGidClassDefFormat2, mapping);
             return;
         }
-        if (trick & SubtableWriteTrick.UseFastCoverage) {
+        if (trick & LookupWriteTrick.UseFastCoverage) {
             const collector = new ClassRunCollector();
             for (const [gid, cls] of mapping) collector.update(gid, cls);
             collector.end();

--- a/packages/io-bin-layout/src/shared/coverage.ts
+++ b/packages/io-bin-layout/src/shared/coverage.ts
@@ -4,7 +4,7 @@ import { Assert, Errors } from "@ot-builder/errors";
 import { OtGlyph } from "@ot-builder/ot-glyphs";
 import { Data } from "@ot-builder/prelude";
 
-import { SubtableWriteTrick } from "../gsub-gpos-shared/general";
+import { LookupWriteTrick } from "../cfg";
 
 // When parsing a coverage we may often run into a situation that
 // something like a "map" will depend on the order of the coverage's items
@@ -133,9 +133,9 @@ export const GidCoverage = {
         }
     }),
     ...Write((frag: Frag, gidList: ReadonlyArray<number>, trick: number = 0) => {
-        if (trick & SubtableWriteTrick.UseFlatCoverage) {
+        if (trick & LookupWriteTrick.UseFlatCoverage) {
             frag.push(OtGidCoverageFormat1, gidList);
-        } else if (trick & SubtableWriteTrick.UseFastCoverage) {
+        } else if (trick & LookupWriteTrick.UseFastCoverage) {
             const collector = new CoverageRunCollector();
             for (let item = 0; item < gidList.length; item++) {
                 collector.update(gidList[item], item);


### PR DESCRIPTION
Apple has bugs about GPOS' contextual lookups. This change adds a trick to prevent it from being produced. It will use chaining lookups instead.