### PR TITLE
Fix transformed component bounding box

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: NPM Setup
@@ -47,7 +47,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: NPM Setup
@@ -72,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: NPM Setup
@@ -97,7 +97,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: NPM Setup

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest] # All operating systems
-        node-version: [16.x, 17.x] # Current and LTS. No history versions
+        node-version: [lts/*, latest] # Current and LTS. No history versions
 
     steps:
     - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest] # All operating systems
-        node-version: [16.x, 17.x] # Current and LTS. No history versions
+        node-version: [lts/*, latest] # Current and LTS. No history versions
 
     steps:
     - uses: actions/checkout@v2
@@ -67,7 +67,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x] # Current and LTS. No history versions
+        node-version: [lts/*] # Current and LTS. No history versions
 
     steps:
     - uses: actions/checkout@v2
@@ -92,7 +92,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x] # Current and LTS. No history versions
+        node-version: [lts/*] # Current and LTS. No history versions
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/prime.yml
+++ b/.github/workflows/prime.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Building
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Building

--- a/.github/workflows/prime.yml
+++ b/.github/workflows/prime.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest] # All operating systems
-        node-version: [16.x, 17.x] # Current and LTS. No history versions
+        node-version: [lts/*, latest] # Current and LTS. No history versions
 
     steps:
     - uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest] # All operating systems
-        node-version: [16.x, 17.x] # Current and LTS. No history versions
+        node-version: [lts/*, latest] # Current and LTS. No history versions
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Validation
@@ -52,7 +52,7 @@ jobs:
         path: .doc-deploy
         token: ${{secrets.SECRET_GITHUB_TOKEN}}
     - name: Use Node.js v14
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '14.x'
     - name: NPM Setup

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest] # All operating systems
-        node-version: [16.x, 17.x] # Current and LTS. No history versions
+        node-version: [lts/*, latest] # Current and LTS. No history versions
 
     steps:
     - uses: actions/checkout@v2

--- a/change/@ot-builder-io-bin-ttf-a95de852-e8a7-4931-8222-7143877fd003.json
+++ b/change/@ot-builder-io-bin-ttf-a95de852-e8a7-4931-8222-7143877fd003.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bounding box calculation around transformed components",
+  "packageName": "@ot-builder/io-bin-ttf",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ot-builder-ot-glyphs-1daa890d-2bd7-49e7-adaf-c909eab91752.json
+++ b/change/@ot-builder-ot-glyphs-1daa890d-2bd7-49e7-adaf-c909eab91752.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bounding box calculation around transformed components",
+  "packageName": "@ot-builder/ot-glyphs",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/doc/pages/references/ot/glyph.mdx
+++ b/doc/pages/references/ot/glyph.mdx
@@ -401,11 +401,11 @@ Defined as <R s={array(Ot.Glyph.Point)} />.
 
  * <Member readonly s={Ot.Glyph.Transform2X3.yx} type={number} />
 
-   X shearing.
+   X shearing. Used by the "Scale10" coefficient in TrueType's `glyf`` table.
 
  * <Member readonly s={Ot.Glyph.Transform2X3.xy} type={number} />
 
-   Y shearing.
+   Y shearing. Used by the "Scale01" coefficient in TrueType's `glyf`` table.
 
  * <Member readonly s={Ot.Glyph.Transform2X3.yy} type={number} />
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "prettier": "^2.5.1",
         "prettier-eslint": "^13.0.0",
         "rimraf": "^3.0.2",
-        "ts-node": "10.5.0",
+        "ts-node": "^10.8.1",
         "tspeg": "^3.2.0",
         "typescript": "^4.5.5"
     }

--- a/packages/io-bin-ttf/src/glyf/read.ts
+++ b/packages/io-bin-ttf/src/glyf/read.ts
@@ -174,8 +174,8 @@ const CompositeGlyph = Read((view, gOrd: Data.Order<OtGlyph>) => {
         const ref = new OtGlyph.TtReference(subGlyf, {
             scaledOffset: !!(flags & ComponentFlag.SCALED_COMPONENT_OFFSET),
             xx: scaleX,
-            yx: scale01,
-            xy: scale10,
+            xy: scale01,
+            yx: scale10,
             yy: scaleY,
             dx: 0,
             dy: 0

--- a/packages/io-bin-ttf/src/glyf/write.ts
+++ b/packages/io-bin-ttf/src/glyf/write.ts
@@ -191,10 +191,10 @@ function writeComponentTransform(frag: Frag, flag: number, transform: OtGlyph.Tr
         frag.push(F2D14, transform.xx);
         frag.push(F2D14, transform.yy);
     } else if (ComponentFlag.WE_HAVE_A_TWO_BY_TWO & flag) {
-        frag.push(F2D14, transform.xx);
-        frag.push(F2D14, transform.yx);
-        frag.push(F2D14, transform.xy);
-        frag.push(F2D14, transform.yy);
+        frag.push(F2D14, transform.xx); // xScale
+        frag.push(F2D14, transform.xy); // scale01
+        frag.push(F2D14, transform.yx); // scale10
+        frag.push(F2D14, transform.yy); // yScale
     }
 }
 const CompositeGlyphData = Write(
@@ -235,10 +235,10 @@ const CompositeGlyphData = Write(
                 targetGID,
                 arg1,
                 arg2,
-                ref.transform.xx,
-                ref.transform.yx,
-                ref.transform.xy,
-                ref.transform.yy
+                ref.transform.xx, // xScale
+                ref.transform.xy, // scale01
+                ref.transform.yx, // scale10
+                ref.transform.yy // yScale
             );
         }
     }

--- a/packages/ot-glyphs/src/general-glyph/point.test.ts
+++ b/packages/ot-glyphs/src/general-glyph/point.test.ts
@@ -9,7 +9,31 @@ const StaticPointFactory: Point.PointFactoryT<number> = {
 
 const Op = new Point.OpT(Algebra.Num, StaticPointFactory);
 
-test("Scale composition -- identity", () => {
+test("Transform Application -- normal", () => {
+    const tb = { xx: 1, yx: 2, xy: 3, yy: 4, dx: 5, dy: 6 };
+    expect(Op.applyTransform({ x: 0, y: 0, kind: 0 }, tb)).toEqual({ x: 5, y: 6, kind: 0 });
+    expect(Op.applyTransform({ x: 1, y: 0, kind: 0 }, tb)).toEqual({ x: 6, y: 9, kind: 0 });
+    expect(Op.applyTransform({ x: 0, y: 1, kind: 0 }, tb)).toEqual({ x: 7, y: 10, kind: 0 });
+});
+
+test("Transform Application -- scaled offset", () => {
+    const tb = { scaledOffset: true, xx: 1, yx: 2, xy: 3, yy: 4, dx: 5, dy: 6 };
+    expect(Op.applyTransform({ x: 0, y: 0, kind: 0 }, tb)).toEqual({ x: 17, y: 39, kind: 0 });
+    expect(Op.applyTransform({ x: 1, y: 0, kind: 0 }, tb)).toEqual({ x: 18, y: 42, kind: 0 });
+    expect(Op.applyTransform({ x: 0, y: 1, kind: 0 }, tb)).toEqual({ x: 19, y: 43, kind: 0 });
+});
+
+test("removeScaledOffset", () => {
+    const tb = { scaledOffset: true, xx: 1, yx: 2, xy: 3, yy: 4, dx: 5, dy: 6 };
+    const tbr = Op.removeScaledOffset(tb);
+    for (let x = -5; x <= 5; x++)
+        for (let y = -5; y <= 5; y++) {
+            const z = { x, y, kind: 0 };
+            expect(Op.applyTransform(z, tb)).toEqual(Op.applyTransform(z, tbr));
+        }
+});
+
+test("Transform composition -- identity", () => {
     const id: Transform2X3.T<number> = { xx: 1, xy: 0, yx: 0, yy: 1, dx: 0, dy: 0 };
     const tb: Transform2X3.T<number> = { xx: 2, xy: 1, yx: 3, yy: 2, dx: 2, dy: 4 };
 
@@ -24,18 +48,18 @@ function transformCompositionTestLoop(ta: Transform2X3.T<number>, tb: Transform2
             const z0 = { x, y, kind: 0 };
             const z1 = Op.applyTransform(Op.applyTransform(z0, tb), ta);
             const z2 = Op.applyTransform(z0, composite);
-            expect({ x, y, z: z2 }).toEqual({ x, y, z: z1 });
+            expect(z1).toEqual(z2);
         }
 }
 
-test("Scale composition -- normal", () => {
+test("Transform composition -- normal", () => {
     transformCompositionTestLoop(
         { xx: 0.5, xy: -0.25, yx: -0.5, yy: 0.25, dx: 1, dy: 1 },
         { xx: 2, xy: 1, yx: 3, yy: 2, dx: 2, dy: 4 }
     );
 });
 
-test("Scale composition -- scaled offset", () => {
+test("Transform composition -- scaled offset", () => {
     transformCompositionTestLoop(
         { scaledOffset: true, xx: 0.5, xy: -0.25, yx: -0.5, yy: 0.25, dx: 1, dy: 1 },
         { scaledOffset: true, xx: 2, xy: 1, yx: 3, yy: 2, dx: 2, dy: 4 }

--- a/packages/ot-glyphs/src/general-glyph/point/point.ts
+++ b/packages/ot-glyphs/src/general-glyph/point/point.ts
@@ -47,6 +47,8 @@ export class OpT<X> implements Algebra.VectorSpace<T<X>, number> {
                 a.kind
             );
         } else {
+            // ⎛ xx yx ⎞ ⎛ x ⎞ + ⎛ dx ⎞ == ⎛ dx + xx * x + yx * y ⎞
+            // ⎝ xy yy ⎠ ⎝ y ⎠ + ⎝ dy ⎠ == ⎝ dy + xy * x + yy * y ⎠
             return this.factory.create(
                 this.vsX.addScale(this.vsX.addScale(t.dx, t.xx, a.x), t.yx, a.y),
                 this.vsX.addScale(this.vsX.addScale(t.dy, t.xy, a.x), t.yy, a.y),

--- a/packages/ot-glyphs/src/general-glyph/transform-2x3.ts
+++ b/packages/ot-glyphs/src/general-glyph/transform-2x3.ts
@@ -1,15 +1,15 @@
 import { Data } from "@ot-builder/prelude";
 
 // 2x3 Transformation like this
-// / xx yx dx \
-// \ xy yy dy /
+// ⎛ xx yx | dx ⎞
+// ⎝ xy yy | dy ⎠
 
 export interface T<X> {
     readonly scaledOffset?: Data.Maybe<boolean>; // Scale offsets or not?
-    readonly xx: number; // H scale
-    readonly yx: number; // H shear
-    readonly xy: number; // V shear
-    readonly yy: number; // V scale
+    readonly xx: number; // X scale
+    readonly yx: number; // X shear
+    readonly xy: number; // Y shear
+    readonly yy: number; // Y scale
     readonly dx: X; // X displacement
     readonly dy: X; // Y displacement
 }


### PR DESCRIPTION
This change fixes how we read scael01/scale10 component in TTF reader to correct the bounding box calculation of glyphs containing transformed components.