### PR TITLE
Upgrade to TypeScript 5

### DIFF
--- a/change/@ot-builder-io-bin-layout-79b731e5-a49a-4814-80f4-1bd93febdf79.json
+++ b/change/@ot-builder-io-bin-layout-79b731e5-a49a-4814-80f4-1bd93febdf79.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Upgrade to typescript 5",
+  "packageName": "@ot-builder/io-bin-layout",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ot-builder-ot-layout-325b3b10-07cc-41cf-a391-490167e1e6dd.json
+++ b/change/@ot-builder-ot-layout-325b3b10-07cc-41cf-a391-490167e1e6dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Upgrade to typescript 5",
+  "packageName": "@ot-builder/ot-layout",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ot-builder-ot-metadata-324b89d3-69dc-4ccf-9442-72b5047886cb.json
+++ b/change/@ot-builder-ot-metadata-324b89d3-69dc-4ccf-9442-72b5047886cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Upgrade to typescript 5",
+  "packageName": "@ot-builder/ot-metadata",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ot-builder-test-util-6549421c-20db-466f-a8cb-17789aa972d0.json
+++ b/change/@ot-builder-test-util-6549421c-20db-466f-a8cb-17789aa972d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Upgrade to typescript 5",
+  "packageName": "@ot-builder/test-util",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "rimraf": "^5.0.0",
         "ts-node": "^10.9.1",
         "tspeg": "^3.2.1",
-        "typescript": "^4.9.4",
+        "typescript": "^5.0.0",
         "which": "^3.0.0"
     }
 }

--- a/packages/io-bin-layout/src/cfg/index.ts
+++ b/packages/io-bin-layout/src/cfg/index.ts
@@ -14,6 +14,8 @@ export interface LayoutCfgPt {
 export const DefaultLayoutProps: LayoutCfgProps = {};
 
 export enum LookupWriteTrick {
+    None = 0,
+
     AvoidUseExtension = 0x0001,
     AvoidBreakSubtable = 0x0002,
     UseFlatCoverage = 0x0004,

--- a/packages/io-bin-layout/src/gsub-gpos-shared/write-lookup-list.ts
+++ b/packages/io-bin-layout/src/gsub-gpos-shared/write-lookup-list.ts
@@ -291,7 +291,9 @@ export const WriteLookupList = Write(function <L extends GsubGpos.LookupProp>(
         for (const dep of lwf.queryDependencies(lookup)) dependentLookups.add(dep);
     }
     for (const lookup of lookups) {
-        const trick = lwc.tricks ? lwc.tricks.get(lookup) || 0 : 0;
+        const trick = lwc.tricks
+            ? lwc.tricks.get(lookup) || LookupWriteTrick.None
+            : LookupWriteTrick.None;
         llw.pushLookup(lookup, dependentLookups.has(lookup), lwf, lwc.gdef, {
             trick,
             gOrd: lwc.gOrd,

--- a/packages/io-bin-layout/src/shared/gpos-adjust.ts
+++ b/packages/io-bin-layout/src/shared/gpos-adjust.ts
@@ -11,6 +11,8 @@ import { OtVar } from "@ot-builder/variance";
 import { Ptr16DeviceTable } from "./device-table";
 
 export enum GposAdjustmentFormat {
+    ELIMINATED = 0,
+
     X_PLACEMENT = 0x0001,
     Y_PLACEMENT = 0x0002,
     X_ADVANCE = 0x0004,
@@ -155,7 +157,7 @@ export const GposAdjustment = {
     },
 
     decideFormat(adj: Gpos.Adjustment) {
-        let f: GposAdjustmentFormat = 0;
+        let f: GposAdjustmentFormat = GposAdjustmentFormat.ELIMINATED;
         if (!OtVar.Ops.isZero(adj.dX)) f |= GposAdjustmentFormat.X_PLACEMENT;
         if (!OtVar.Ops.isZero(adj.dY)) f |= GposAdjustmentFormat.Y_PLACEMENT;
         if (!OtVar.Ops.isZero(adj.dWidth)) f |= GposAdjustmentFormat.X_ADVANCE;

--- a/packages/io-bin-layout/src/test/math.test.ts
+++ b/packages/io-bin-layout/src/test/math.test.ts
@@ -108,9 +108,9 @@ test("Math - variants", () => {
         expect(math.variants?.vertical?.get(gOrd.at(10))).toEqual(
             new OtMath.GlyphConstruction(
                 new OtMath.GlyphAssembly({ value: 0 }, [
-                    new OtMath.GlyphPart(uni239D, 0, 35, 884, 0),
+                    new OtMath.GlyphPart(uni239D, 0, 35, 884, OtMath.GlyphPartFlags.None),
                     new OtMath.GlyphPart(uni239C, 15, 15, 326, OtMath.GlyphPartFlags.Extender),
-                    new OtMath.GlyphPart(uni239B, 35, 0, 884, 0)
+                    new OtMath.GlyphPart(uni239B, 35, 0, 884, OtMath.GlyphPartFlags.None)
                 ]),
                 [
                     new OtMath.GlyphVariantRecord(parenLeft, 942),

--- a/packages/ot-layout/src/math/index.ts
+++ b/packages/ot-layout/src/math/index.ts
@@ -103,6 +103,7 @@ export class GlyphVariantRecord {
     ) {}
 }
 export enum GlyphPartFlags {
+    None = 0,
     Extender = 0x0001
 }
 export class GlyphPart {

--- a/packages/ot-metadata/src/tables/head.ts
+++ b/packages/ot-metadata/src/tables/head.ts
@@ -3,6 +3,7 @@ import { F16D16, Int16, UInt16, UInt32 } from "@ot-builder/primitive";
 export const Tag = "head";
 
 export enum Flags {
+    None = 0,
     BaseLineYAt0 = 1 << 0,
     LeftSidebearingAtX0 = 1 << 1,
     InstructionsMayDependOnPointSize = 1 << 2,
@@ -22,6 +23,7 @@ export enum Flags {
 }
 
 export enum MacStyle {
+    None = 0,
     Bold = 1 << 0,
     Italic = 1 << 1,
     Underline = 1 << 2,
@@ -47,7 +49,7 @@ export class Table {
     public fontRevision: F16D16 = 0;
     public readonly checkSumAdjust: UInt32 = 0;
     public readonly magicNumber: UInt32 = 0x5f0f3cf5;
-    public flags: Flags = 0;
+    public flags: Flags = Flags.None;
     public unitsPerEm: UInt16 = 1000;
     public created: Date = new Date();
     public modified: Date = new Date();
@@ -55,7 +57,7 @@ export class Table {
     public yMin: Int16 = 0; // VOLATILE
     public xMax: Int16 = 0; // VOLATILE
     public yMax: Int16 = 0; // VOLATILE
-    public macStyle: MacStyle = 0;
+    public macStyle: MacStyle = MacStyle.None;
     public lowestRecPPEM: UInt16 = 0;
     public fontDirectionHint: FontDirectionHint = 2;
     public indexToLocFormat: Int16 = 0; // VOLATILE

--- a/packages/ot-metadata/src/tables/os2.ts
+++ b/packages/ot-metadata/src/tables/os2.ts
@@ -4,6 +4,7 @@ import { OtVar } from "@ot-builder/variance";
 export const Tag = "OS/2";
 
 export enum FsType {
+    None = 0,
     InstallableEmbedding = 1 << 0,
     RestrictedLicense = 1 << 1,
     PreviewPrintLicense = 1 << 2,
@@ -17,6 +18,7 @@ export enum FsType {
 }
 
 export enum FsSelection {
+    None = 0,
     ITALIC = 1 << 0,
     UNDERSCORE = 1 << 1,
     NEGATIVE = 1 << 2,
@@ -30,6 +32,7 @@ export enum FsSelection {
 }
 
 export enum CodePageRange1 {
+    None = 0,
     CP1252 = 1 << 0,
     CP1250 = 1 << 1,
     CP1251 = 1 << 2,
@@ -64,6 +67,7 @@ export enum CodePageRange1 {
     Symbol = 1 << 31
 }
 export enum CodePageRange2 {
+    None = 0,
     Oem8 = 1 << 0,
     Oem9 = 1 << 1,
     Oem10 = 1 << 2,
@@ -99,6 +103,7 @@ export enum CodePageRange2 {
 }
 
 export enum UnicodeRange1 {
+    None = 0,
     BasicLatin = 1 << 0,
     Latin1Supplement = 1 << 1,
     LatinExtendedA = 1 << 2,
@@ -134,6 +139,7 @@ export enum UnicodeRange1 {
 }
 
 export enum UnicodeRange2 {
+    None = 0,
     SuperscriptsAndSubscripts = 1 << 0,
     CurrencySymbols = 1 << 1,
     CombiningDiacriticalMarksForSymbols = 1 << 2,
@@ -168,6 +174,7 @@ export enum UnicodeRange2 {
     ArabicPresentationFormsA = 1 << 31
 }
 export enum UnicodeRange3 {
+    None = 0,
     CombiningHalfMarks = 1 << 0,
     VerticalFormsAndCJKCompatibilityForms = 1 << 1,
     SmallFormVariants = 1 << 2,
@@ -202,6 +209,7 @@ export enum UnicodeRange3 {
     NewTaiLue = 1 << 31
 }
 export enum UnicodeRange4 {
+    None = 0,
     Buginese = 1 << 0,
     Glagolitic = 1 << 1,
     Tifinagh = 1 << 2,
@@ -249,7 +257,7 @@ export class Table {
     public xAvgCharWidth: Primitive.Int16 = 0;
     public usWeightClass: Primitive.UInt16 = 0;
     public usWidthClass: Primitive.UInt16 = 0;
-    public fsType: FsType = 0;
+    public fsType: FsType = FsType.None;
     public ySubscriptXSize: OtVar.Value = 0;
     public ySubscriptYSize: OtVar.Value = 0;
     public ySubscriptXOffset: OtVar.Value = 0;
@@ -262,12 +270,12 @@ export class Table {
     public yStrikeoutPosition: OtVar.Value = 0;
     public sFamilyClass: Primitive.Int16 = 0;
     public panose: Panose = new Panose();
-    public ulUnicodeRange1: UnicodeRange1 = 0;
-    public ulUnicodeRange2: UnicodeRange2 = 0;
-    public ulUnicodeRange3: UnicodeRange3 = 0;
-    public ulUnicodeRange4: UnicodeRange4 = 0;
+    public ulUnicodeRange1: UnicodeRange1 = UnicodeRange1.None;
+    public ulUnicodeRange2: UnicodeRange2 = UnicodeRange2.None;
+    public ulUnicodeRange3: UnicodeRange3 = UnicodeRange3.None;
+    public ulUnicodeRange4: UnicodeRange4 = UnicodeRange4.None;
     public achVendID: Primitive.Tag = "UKWN";
-    public fsSelection: FsSelection = 0;
+    public fsSelection: FsSelection = FsSelection.None;
     public usFirstCharIndex: Primitive.UInt16 = 0;
     public usLastCharIndex: Primitive.UInt16 = 0;
     public sTypoAscender: OtVar.Value = 0;
@@ -275,8 +283,8 @@ export class Table {
     public sTypoLineGap: OtVar.Value = 0;
     public usWinAscent: OtVar.Value = 0;
     public usWinDescent: OtVar.Value = 0;
-    public ulCodePageRange1: CodePageRange1 = 0;
-    public ulCodePageRange2: CodePageRange2 = 0;
+    public ulCodePageRange1: CodePageRange1 = CodePageRange1.None;
+    public ulCodePageRange2: CodePageRange2 = CodePageRange2.None;
     public sxHeight: OtVar.Value = 0;
     public sCapHeight: OtVar.Value = 0;
     public usDefaultChar: Primitive.UInt16 = 0;

--- a/packages/test-util/src/glyph-identity.ts
+++ b/packages/test-util/src/glyph-identity.ts
@@ -5,6 +5,8 @@ import { OtVar } from "@ot-builder/variance";
 import * as FastMatch from "./fast-match";
 
 export enum CompareMode {
+    None = 0,
+
     RemoveCycle = 1,
     CompareMetric = 2,
     CompareInstructions = 4,
@@ -16,7 +18,7 @@ export enum CompareMode {
 export function test(
     expected: OtGlyph,
     actual: OtGlyph,
-    mode: CompareMode = 0,
+    mode: CompareMode = CompareMode.None,
     tolerance = 1,
     place = ""
 ) {
@@ -36,7 +38,7 @@ export function test(
 function testGeometry(
     geomE: Data.Maybe<OtGlyph.Geometry>,
     geomA: Data.Maybe<OtGlyph.Geometry>,
-    mode: CompareMode = 0,
+    mode: CompareMode = CompareMode.None,
     tolerance = 1,
     place = ""
 ) {
@@ -49,7 +51,7 @@ function testGeometry(
 function testInitGeometry(
     geomE: OtGlyph.Geometry,
     geomA: OtGlyph.Geometry,
-    mode: CompareMode = 0,
+    mode: CompareMode = CompareMode.None,
     tolerance = 1,
     place = ""
 ) {
@@ -88,7 +90,7 @@ function testInitGeometry(
 export function testStore<GS extends Data.OrderStore<OtGlyph>>(
     expected: GS,
     actual: GS,
-    mode: CompareMode = 0,
+    mode: CompareMode = CompareMode.None,
     tolerance = 1
 ) {
     const goA = expected.decideOrder();
@@ -183,7 +185,7 @@ function testReference(
 function testHints(
     hintE: Data.Maybe<OtGlyph.Hint>,
     hintA: Data.Maybe<OtGlyph.Hint>,
-    mode: CompareMode = 0,
+    mode: CompareMode = CompareMode.None,
     tolerance = 1,
     place = ""
 ) {
@@ -197,7 +199,7 @@ function testHints(
 function testInitialHints(
     hintE: OtGlyph.Hint,
     hintA: OtGlyph.Hint,
-    mode: CompareMode = 0,
+    mode: CompareMode = CompareMode.None,
     tolerance = 1,
     place = ""
 ) {


### PR DESCRIPTION
This change upgrades TS version to 5.0.
Changes are minor: TS5 made bitflags enum more strict, so here we need to convert certain 0s into enum variants that is assigned to 0.