### PR TITLE
Fix gsub reverse write

### DIFF
--- a/change/@ot-builder-io-bin-layout-92ba7240-3152-4d45-9188-a5e79f3ab54c.json
+++ b/change/@ot-builder-io-bin-layout-92ba7240-3152-4d45-9188-a5e79f3ab54c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix GSUB reverse lookup write's backtrack coverages' ordering",
+  "packageName": "@ot-builder/io-bin-layout",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/io-bin-layout/src/lookups/gsub-reverse.ts
+++ b/packages/io-bin-layout/src/lookups/gsub-reverse.ts
@@ -54,7 +54,12 @@ const SubtableFormat1 = {
 
         frag.uint16(1)
             .push(Ptr16GidCoverage, CovUtils.gidListFromAuxMap(gm), ctx.trick)
-            .push(SimpleCoverageArray, rule.match.slice(0, rule.doSubAt), ctx.gOrd, ctx.trick)
+            .push(
+                SimpleCoverageArray,
+                rule.match.slice(0, rule.doSubAt).reverse(),
+                ctx.gOrd,
+                ctx.trick
+            )
             .push(SimpleCoverageArray, rule.match.slice(rule.doSubAt + 1), ctx.gOrd, ctx.trick)
             .uint16(gm.length)
             .array(UInt16, CovUtils.valueListFromAuxMap(gm));

--- a/packages/io-bin-layout/src/lookups/test/contextual.test.ts
+++ b/packages/io-bin-layout/src/lookups/test/contextual.test.ts
@@ -88,11 +88,13 @@ test("GSUB/GPOS Chaining : Simple", () => {
     lookup.rules.push({
         match: [
             TuGlyphSet(gOrd, 0, 4, 5, 8),
+            TuGlyphSet(gOrd, 0, 3, 7, 9),
             TuGlyphSet(gOrd, 2, 78, 1, 34),
             TuGlyphSet(gOrd, 4, 99, 10, 8),
-            TuGlyphSet(gOrd, 8, 10, 12, 13, 15)
+            TuGlyphSet(gOrd, 8, 10, 12, 13, 15),
+            TuGlyphSet(gOrd, 9, 11)
         ],
-        inputBegins: 1,
+        inputBegins: 2,
         inputEnds: 3,
         applications: [
             { at: 0, apply: lOrd.at(1) },

--- a/packages/io-bin-layout/src/lookups/test/gsub-reverse.test.ts
+++ b/packages/io-bin-layout/src/lookups/test/gsub-reverse.test.ts
@@ -35,6 +35,17 @@ test("GSUB Reverse sub : Simple", () => {
         doSubAt: 1,
         replacement: Disorder.shuffleMap(new Map([[gOrd.at(2), gOrd.at(4)]]))
     });
+    lookup.rules.push({
+        match: [
+            TuGlyphSet(gOrd, 1, 2, 3, 4),
+            TuGlyphSet(gOrd, 5, 6, 7, 8),
+            TuGlyphSet(gOrd, 2),
+            TuGlyphSet(gOrd, 1, 3, 5, 7),
+            TuGlyphSet(gOrd, 2, 4, 6, 8)
+        ],
+        doSubAt: 2,
+        replacement: Disorder.shuffleMap(new Map([[gOrd.at(2), gOrd.at(4)]]))
+    });
 
     LookupRoundTripTest(lookup, roundtripConfig);
 });


### PR DESCRIPTION
The writer's handler for GSUB Reverse' backtrack coverages is incorrectly implemented, causing roundtrip mismatch when `backtrackGlyphCount` > 1.