### PR TITLE
Rectifier: fix OS/2.xAvgCharWidth calculation

### DIFF
--- a/change/@ot-builder-rectify-8fd9937f-e9ee-4b53-8eff-624f391875eb.json
+++ b/change/@ot-builder-rectify-8fd9937f-e9ee-4b53-8eff-624f391875eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Rectifier: Handle OS2::xAvgCharWidth",
+  "packageName": "@ot-builder/rectify",
+  "email": "otbbuilder-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/rectify/src/meta/os2.ts
+++ b/packages/rectify/src/meta/os2.ts
@@ -4,7 +4,7 @@ import { CoordRectifier } from "../interface";
 
 export function rectifyOs2Table(rec: CoordRectifier, table: Ot.Os2.Table) {
     const newTable = new Ot.Os2.Table(table.version);
-    newTable.xAvgCharWidth = table.xAvgCharWidth;
+    newTable.xAvgCharWidth = Ot.Var.Ops.originOf(rec.coord(table.xAvgCharWidth));
     newTable.usWeightClass = table.usWeightClass;
     newTable.usWidthClass = table.usWidthClass;
     newTable.fsType = table.fsType;


### PR DESCRIPTION
This value is a metric so it shall be rectified (even though in most cases it will be overwritten in later "stat" stage.